### PR TITLE
bump image tag in pulumi

### DIFF
--- a/pulumi/Pulumi.dev.yaml
+++ b/pulumi/Pulumi.dev.yaml
@@ -7,7 +7,7 @@ config:
   ahb-tabellen:ghcr_token:
     secure: AAABAEg7fEk2P91sxA8mlsQ5AueGPcKpU5H8jCLGvH82HsWD1NkdQLT69wDwMfdI7Nc+jSdwJC4Wx/ym4m3HUMGxgeK9RJt0
   ahb-tabellen:imageName: ghcr.io/hochfrequenz/ahbesser
-  ahb-tabellen:imageTag: v0.0.2
+  ahb-tabellen:imageTag: v0.0.3
   ahb-tabellen:memory: "2"
   azure-native:location: germanywestcentral
   pulumi:template: container-azure-python


### PR DESCRIPTION
This PR bumpes only the version tag of the docker image in the pulumi config.

In the future we will automate this with GH actions, so a Release should trigger the image build process and afterwards use the new version and deploy the newest version on stage using pulumi