### PR TITLE
✨ Add component to copy current URL

### DIFF
--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
@@ -43,8 +43,7 @@
             class="rounded-full bg-primary py-3 px-5 text-white"
             (click)="iconCopyUrl.onClickCopyUrl()"
           >
-            <app-icon-copy-url #iconCopyUrl>
-            </app-icon-copy-url>
+            <app-icon-copy-url #iconCopyUrl> </app-icon-copy-url>
           </button>
           <button
             class="rounded-full bg-primary text-[16px] font-bold py-3 px-5 text-white"

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
@@ -38,12 +38,21 @@
             [totalResults]="table()?.markElements()?.length"
           />
         </div>
-        <button
-          class="rounded-full bg-primary text-[16px] font-bold py-3 px-5 text-white mt-5"
-          (click)="onClickExport()"
-        >
-          Export XLSX
-        </button>
+        <div class="flex justify-end items-center space-x-3 mt-3">
+          <button
+            class="rounded-full bg-primary py-3 px-5 text-white"
+            (click)="iconCopyUrl.onClickCopyUrl()"
+          >
+            <app-icon-copy-url #iconCopyUrl>
+            </app-icon-copy-url>
+          </button>
+          <button
+            class="rounded-full bg-primary text-[16px] font-bold py-3 px-5 text-white"
+            (click)="onClickExport()"
+          >
+            Export XLSX
+          </button>
+        </div>
       </section>
     </div>
     <section class="flex-1 overflow-auto">

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -18,6 +18,7 @@ import { AhbSearchFormHeaderComponent } from '../../components/ahb-search-form-h
 import { InputSearchEnhancedComponent } from '../../../../shared/components/input-search-enhanced/input-search-enhanced.component';
 import { HighlightPipe } from '../../../../shared/pipes/highlight.pipe';
 import { scrollToElement } from '../../../../core/helper/scroll-to-element';
+import { IconCopyUrlComponent } from '../../../../shared/components/icon-copy-url/icon-copy-url.component';
 
 @Component({
   selector: 'app-ahb-page',
@@ -32,6 +33,7 @@ import { scrollToElement } from '../../../../core/helper/scroll-to-element';
     AhbSearchFormHeaderComponent,
     InputSearchEnhancedComponent,
     HighlightPipe,
+    IconCopyUrlComponent,
   ],
   templateUrl: './ahb-page.component.html',
 })

--- a/src/app/shared/components/icon-copy-url/icon-copy-url.component.html
+++ b/src/app/shared/components/icon-copy-url/icon-copy-url.component.html
@@ -1,0 +1,30 @@
+<div class="relative">
+  <div class="flex items-center">
+    <svg 
+      xmlns="http://www.w3.org/2000/svg" 
+      fill="none" 
+      viewBox="0 0 24 24" 
+      stroke-width="1.5" 
+      stroke="currentColor" 
+      class="size-6"
+    >
+      <path 
+        stroke-linecap="round" 
+        stroke-linejoin="round" 
+        d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
+      />
+    </svg>
+    <ng-content></ng-content>
+  </div>
+
+  <div 
+    #popover
+    id="popover-click" 
+    role="tooltip" 
+    class="absolute -left-5 mt-6 z-10 invisible inline-block w-44 py-2 transition-opacity duration-300 bg-primary rounded-full shadow-sm opacity-0 before:content-[''] before:absolute before:top-0 before:left-6 before:-translate-y-full before:border-8 before:border-x-transparent before:border-t-transparent before:border-b-primary"
+  >
+    <h3 class="text-sm text-white">
+      Link erfolgreich kopiert.
+    </h3>
+  </div>
+</div>

--- a/src/app/shared/components/icon-copy-url/icon-copy-url.component.html
+++ b/src/app/shared/components/icon-copy-url/icon-copy-url.component.html
@@ -1,30 +1,28 @@
 <div class="relative">
   <div class="flex items-center">
-    <svg 
-      xmlns="http://www.w3.org/2000/svg" 
-      fill="none" 
-      viewBox="0 0 24 24" 
-      stroke-width="1.5" 
-      stroke="currentColor" 
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
       class="size-6"
     >
-      <path 
-        stroke-linecap="round" 
-        stroke-linejoin="round" 
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
         d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
       />
     </svg>
     <ng-content></ng-content>
   </div>
 
-  <div 
+  <div
     #popover
-    id="popover-click" 
-    role="tooltip" 
+    id="popover-click"
+    role="tooltip"
     class="absolute -left-5 mt-6 z-10 invisible inline-block w-44 py-2 transition-opacity duration-300 bg-primary rounded-full shadow-sm opacity-0 before:content-[''] before:absolute before:top-0 before:left-6 before:-translate-y-full before:border-8 before:border-x-transparent before:border-t-transparent before:border-b-primary"
   >
-    <h3 class="text-sm text-white">
-      Link erfolgreich kopiert.
-    </h3>
+    <h3 class="text-sm text-white">Link erfolgreich kopiert.</h3>
   </div>
 </div>

--- a/src/app/shared/components/icon-copy-url/icon-copy-url.component.spec.ts
+++ b/src/app/shared/components/icon-copy-url/icon-copy-url.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IconCopyUrlComponent } from './icon-copy-url.component';
+
+describe('IconCopyUrlComponent', () => {
+  let component: IconCopyUrlComponent;
+  let fixture: ComponentFixture<IconCopyUrlComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IconCopyUrlComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(IconCopyUrlComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/icon-copy-url/icon-copy-url.component.spec.ts
+++ b/src/app/shared/components/icon-copy-url/icon-copy-url.component.spec.ts
@@ -1,17 +1,28 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { IconCopyUrlComponent } from './icon-copy-url.component';
+import { Renderer2 } from '@angular/core';
 
 describe('IconCopyUrlComponent', () => {
   let component: IconCopyUrlComponent;
   let fixture: ComponentFixture<IconCopyUrlComponent>;
+  let mockRenderer: jest.Mocked<Renderer2>;
 
   beforeEach(async () => {
+    mockRenderer = {
+      removeClass: jest.fn(),
+      addClass: jest.fn(),
+    } as unknown as jest.Mocked<Renderer2>;
+
     await TestBed.configureTestingModule({
-      imports: [IconCopyUrlComponent]
-    })
-    .compileComponents();
-    
+      imports: [IconCopyUrlComponent],
+      providers: [{ provide: Renderer2, useValue: mockRenderer }],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(IconCopyUrlComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -20,4 +31,23 @@ describe('IconCopyUrlComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should copy current URL to clipboard', fakeAsync(() => {
+    Object.defineProperty(window, 'location', {
+      value: { href: 'https://no-edifacts-given.com' },
+      writable: true,
+    });
+
+    const writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      writable: true,
+    });
+
+    component.onClickCopyUrl();
+
+    tick();
+    expect(writeTextMock).toHaveBeenCalledWith('https://no-edifacts-given.com');
+    tick(3000);
+  }));
 });

--- a/src/app/shared/components/icon-copy-url/icon-copy-url.component.ts
+++ b/src/app/shared/components/icon-copy-url/icon-copy-url.component.ts
@@ -12,13 +12,11 @@ export class IconCopyUrlComponent {
 
   onClickCopyUrl() {
     const currentUrl = window.location.href;
-    
-    navigator.clipboard.writeText(currentUrl).then(
-      () => {
-        this.showPopover();
-        setTimeout(() => this.hidePopover(), 3000);
-      },
-    );
+
+    navigator.clipboard.writeText(currentUrl).then(() => {
+      this.showPopover();
+      setTimeout(() => this.hidePopover(), 3000);
+    });
   }
 
   private showPopover() {

--- a/src/app/shared/components/icon-copy-url/icon-copy-url.component.ts
+++ b/src/app/shared/components/icon-copy-url/icon-copy-url.component.ts
@@ -1,0 +1,41 @@
+import { Component, ElementRef, ViewChild, Renderer2 } from '@angular/core';
+
+@Component({
+  selector: 'app-icon-copy-url',
+  standalone: true,
+  templateUrl: './icon-copy-url.component.html',
+})
+export class IconCopyUrlComponent {
+  @ViewChild('popover') popover!: ElementRef;
+
+  constructor(private renderer: Renderer2) {}
+
+  onClickCopyUrl() {
+    const currentUrl = window.location.href;
+    
+    navigator.clipboard.writeText(currentUrl).then(
+      () => {
+        this.showPopover();
+        setTimeout(() => this.hidePopover(), 3000);
+      },
+    );
+  }
+
+  private showPopover() {
+    if (this.popover && this.popover.nativeElement) {
+      this.renderer.removeClass(this.popover.nativeElement, 'invisible');
+      this.renderer.removeClass(this.popover.nativeElement, 'opacity-0');
+      this.renderer.addClass(this.popover.nativeElement, 'visible');
+      this.renderer.addClass(this.popover.nativeElement, 'opacity-100');
+    }
+  }
+
+  private hidePopover() {
+    if (this.popover && this.popover.nativeElement) {
+      this.renderer.addClass(this.popover.nativeElement, 'invisible');
+      this.renderer.addClass(this.popover.nativeElement, 'opacity-0');
+      this.renderer.removeClass(this.popover.nativeElement, 'visible');
+      this.renderer.removeClass(this.popover.nativeElement, 'opacity-100');
+    }
+  }
+}

--- a/src/app/shared/components/input-search-enhanced/input-search-enhanced.component.html
+++ b/src/app/shared/components/input-search-enhanced/input-search-enhanced.component.html
@@ -1,4 +1,4 @@
-<div class="inline-block bg-tint rounded-full py-3 px-5 w-full flex">
+<div class="bg-tint rounded-full py-3 px-5 w-full flex">
   <!-- search-icon -->
   <button class="align-middle cursor-default">
     <app-icon-magnifying-glass />


### PR DESCRIPTION
tried to match the popover with the design of the website; of course we can adjust it further if necessary.

the button has already been tested to work well with URLs containing a query string #109

![Screenshot 2024-08-02 232729](https://github.com/user-attachments/assets/4b222ad3-7e3f-4b90-9736-57b51b790a8d)