### PR TITLE
➗ Split `meta.direction` into `sender` and `empfaenger`

### DIFF
--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
@@ -18,8 +18,10 @@
         </h3>
         <p class="text-[20px] mb-5">{{ ahb.meta.description }}</p>
         <p class="text-[14px]">
-          <span class="font-bold"> Sender/Empfänger: </span>
-          {{ ahb.meta.direction }}
+          <span class="font-bold">Sender:</span>
+          {{ getSenderEmpfaenger(ahb.meta.direction).sender }}<br />
+          <span class="font-bold">Empfänger:</span>
+          {{ getSenderEmpfaenger(ahb.meta.direction).empfaenger }}
         </p>
         <p class="text-[14px]">
           <span class="font-bold"> Format: </span>

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.spec.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.spec.ts
@@ -28,5 +28,49 @@ describe('AhbPageComponent', () => {
     expect(html).toContain('loading ...');
   });
 
+  it('should split sender and empfaenger without "an" keyword', () => {
+    const fixture = MockRender(AhbPageComponent, {
+      formatVersion: 'FV123',
+      pruefi: '123',
+    });
+    const component = fixture.point.componentInstance;
+
+    const testDirection = 'ABC an XYZ';
+    const result = component.getSenderEmpfaenger(testDirection);
+
+    expect(result.sender).toBe('ABC');
+    expect(result.empfaenger).toBe('XYZ');
+    expect(result.sender).not.toContain(' an ');
+    expect(result.empfaenger).not.toContain(' an ');
+  });
+
+  it('should handle direction without empfaenger', () => {
+    const fixture = MockRender(AhbPageComponent, {
+      formatVersion: 'FV123',
+      pruefi: '123',
+    });
+    const component = fixture.point.componentInstance;
+
+    const testDirection = 'ABC';
+    const result = component.getSenderEmpfaenger(testDirection);
+
+    expect(result.sender).toBe('ABC');
+    expect(result.empfaenger).toBe('');
+  });
+
+  it('should handle empty direction', () => {
+    const fixture = MockRender(AhbPageComponent, {
+      formatVersion: 'FV123',
+      pruefi: '123',
+    });
+    const component = fixture.point.componentInstance;
+
+    const testDirection = '';
+    const result = component.getSenderEmpfaenger(testDirection);
+
+    expect(result.sender).toBe('');
+    expect(result.empfaenger).toBe('');
+  });
+
   // todo add more tests
 });

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -91,6 +91,17 @@ export class AhbPageComponent {
     return mapping[key];
   }
 
+  // to split meta.direction into sender and empfaenger
+  getSenderEmpfaenger(direction: string): {
+    sender: string;
+    empfaenger: string;
+  } {
+    const [sender, empfaenger] = direction
+      .split(' an ')
+      .map((part) => part.trim());
+    return { sender, empfaenger: empfaenger || '' };
+  }
+
   onClickExport() {
     alert('not implemented');
   }

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -91,7 +91,7 @@ export class AhbPageComponent {
     return mapping[key];
   }
 
-  // to split meta.direction into sender and empfaenger
+  // splitting meta.direction into sender and empfaenger
   getSenderEmpfaenger(direction: string): {
     sender: string;
     empfaenger: string;


### PR DESCRIPTION
![Screenshot 2024-08-07 095723](https://github.com/user-attachments/assets/a3b3edbf-55ff-4a14-a824-038e673957bd)