### PR TITLE
🐳🪝 Pull latest azurite image automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,9 @@ updates:
       interval: "weekly"
     reviewers:
       - "hf-krechan"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "@Hochfrequenz/frontend-developers-review-team"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite
+    image: mcr.microsoft.com/azure-storage/azurite:latest
     ports:
       - 10000:10000
     command: azurite-blob --blobHost 0.0.0.0


### PR DESCRIPTION
recent error when attempting to start the app locally
```sh
[server:start] RestError: The API version 2024-08-04 is not supported by Azurite. Please upgrade Azurite to latest version and retry. If you are using Azurite in Visual Studio, please check you have installed latest Visual Studio patch. Azurite command line parameter "--skipApiVersionCheck" or Visual Studio Code configuration "Skip Api Version Check" can skip this error.
```

- would it hurt to add the `:latest` tag to the azurite image, since its only for local development and wouldn't hurt any production stuff?

- dependabot's docker bumps include image version updates inside `docker-compose.yaml` (according to ChatGPT)