### PR TITLE
🔧 Migrate from `eslintrc` to `eslint.config`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,49 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+    recommendedConfig: js.configs.recommended,
+    allConfig: js.configs.all
+});
+
+export default [{
+    ignores: ["projects/**/*", "**/dist"],
+}, ...compat.extends(
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@angular-eslint/recommended",
+    "plugin:@angular-eslint/template/process-inline-templates",
+).map(config => ({
+    ...config,
+    files: ["**/*.ts"],
+})), {
+    files: ["**/*.ts"],
+
+    rules: {
+        "@angular-eslint/directive-selector": ["error", {
+            type: "attribute",
+            prefix: "app",
+            style: "camelCase",
+        }],
+
+        "@angular-eslint/component-selector": ["error", {
+            type: "element",
+            prefix: "app",
+            style: "kebab-case",
+        }],
+    },
+}, ...compat.extends(
+    "plugin:@angular-eslint/template/recommended",
+    "plugin:@angular-eslint/template/accessibility",
+).map(config => ({
+    ...config,
+    files: ["**/*.html"],
+})), {
+    files: ["**/*.html"],
+    rules: {},
+}];


### PR DESCRIPTION
required for #175

generated via `$ npx @eslint/migrate-config .eslintrc.json`

- `eslint.config` is mandatory for eslint.  
- `eslintrc.json` is still required by `ng lint`

<img width="583" alt="Screenshot 2024-08-19 at 11 59 29" src="https://github.com/user-attachments/assets/7c703d23-9979-4948-9304-3f9b8b6f5971">