### PR TITLE
Fix auto scrolling through highlighted search matches

### DIFF
--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
@@ -90,6 +90,7 @@ export class AhbTableComponent {
     if (markElements.length > 0) {
       const nextIndex = (this.markIndex() + 1) % markElements.length;
       this.markIndex.set(nextIndex);
+      this.scrollToHighlightedElement();
     }
   }
 
@@ -99,7 +100,19 @@ export class AhbTableComponent {
       const previousIndex =
         (this.markIndex() - 1 + markElements.length) % markElements.length;
       this.markIndex.set(previousIndex);
+      this.scrollToHighlightedElement();
     }
+  }
+
+  scrollToHighlightedElement() {
+    const selectedElement = this.selectedMarkElement();
+    const header = this.header();
+    const headerHeight =
+      header?.nativeElement.getBoundingClientRect().height ?? 0;
+    this.selectElement.emit({
+      element: selectedElement || this.elementRef.nativeElement,
+      offsetY: headerHeight,
+    });
   }
 
   // determines each time the section_name changes to add a bold rule in ahb-table.component.html

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
@@ -30,11 +30,11 @@ export class AhbTableComponent {
 
   selectElement = output<{ element: HTMLElement; offsetY: number }>();
 
-  private highlightSignal = signal<string | undefined>(undefined);
+  private highlightSignal = computed(() => this.highlight());
   markIndex = signal(0);
 
   markElements = computed<HTMLElement[]>(() => {
-    const highlight = this.getHighlight();
+    const highlight = this.highlight();
     const nativeElement = this.elementRef.nativeElement;
     if (!highlight || !nativeElement) {
       return [];
@@ -53,8 +53,8 @@ export class AhbTableComponent {
 
   constructor(private readonly elementRef: ElementRef) {
     effect(() => {
-      this.highlightSignal.set(this.highlight());
-      this.markIndex.set(0);
+      this.highlight();
+      this.resetMarkIndex();
     });
 
     effect(() => {
@@ -77,8 +77,7 @@ export class AhbTableComponent {
     });
   }
 
-  setHighlight(value: string | undefined) {
-    this.highlightSignal.set(value);
+  resetMarkIndex() {
     this.markIndex.set(0);
   }
 

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
@@ -53,11 +53,6 @@ export class AhbTableComponent {
 
   constructor(private readonly elementRef: ElementRef) {
     effect(() => {
-      this.highlight();
-      this.resetMarkIndex();
-    });
-
-    effect(() => {
       const selectedMarkElement = this.selectedMarkElement();
       if (selectedMarkElement === null) {
         return;
@@ -67,18 +62,13 @@ export class AhbTableComponent {
       markElements.forEach((el) => el.classList.remove('bg-orange-500'));
       selectedMarkElement.classList.add('bg-orange-500');
       // notify outer scroll container
-      const header = this.header();
-      const headerHeight =
-        header?.nativeElement.getBoundingClientRect().height ?? 0;
-      this.selectElement.emit({
-        element: selectedMarkElement,
-        offsetY: headerHeight,
-      });
+      this.scrollToHighlightedElement();
     });
   }
 
   resetMarkIndex() {
     this.markIndex.set(0);
+    this.scrollToHighlightedElement();
   }
 
   getHighlight(): string | undefined {

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
@@ -17,7 +17,7 @@
     />
   </app-header>
 
-  <div class="flex-1 flex flex-col overflow-auto">
+  <div class="flex-1 flex flex-col overflow-auto" #scroll>
     <div>
       @if (ahb$ | async; as ahb) {
         <div class="flex-none flex flex-col md:flex-row mb-10">
@@ -53,7 +53,7 @@
       }
     </div>
 
-    <div #scroll>
+    <div>
       @if (lines$ | async; as lines) {
         <app-ahb-table
           [lines]="lines"

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -19,7 +19,6 @@ import { Observable, map, shareReplay, tap } from 'rxjs';
 import { AhbSearchFormHeaderComponent } from '../../components/ahb-search-form-header/ahb-search-form-header.component';
 import { InputSearchEnhancedComponent } from '../../../../shared/components/input-search-enhanced/input-search-enhanced.component';
 import { HighlightPipe } from '../../../../shared/pipes/highlight.pipe';
-import { scrollToElement } from '../../../../core/helper/scroll-to-element';
 import { ExportButtonComponent } from '../../components/export-button/export-button.component';
 import { IconCopyUrlComponent } from '../../../../shared/components/icon-copy-url/icon-copy-url.component';
 
@@ -99,7 +98,10 @@ export class AhbPageComponent implements OnInit {
     const tableComponent = this.table();
     if (tableComponent) {
       tableComponent.resetMarkIndex();
-      tableComponent.nextResult();
+      setTimeout(() => {
+        tableComponent.nextResult();
+        tableComponent.scrollToHighlightedElement();
+      }, 0);
     }
     this.initialSearchQuery = null; // Reset after first use
   }
@@ -177,6 +179,16 @@ export class AhbPageComponent implements OnInit {
     if (!scrollContainer?.nativeElement) {
       return;
     }
-    scrollToElement(element, offsetY, scrollContainer.nativeElement);
+    const containerRect = scrollContainer.nativeElement.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const scrollTop =
+      elementRect.top -
+      containerRect.top +
+      scrollContainer.nativeElement.scrollTop -
+      offsetY;
+    scrollContainer.nativeElement.scrollTo({
+      top: scrollTop,
+      behavior: 'smooth',
+    });
   }
 }

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -98,7 +98,7 @@ export class AhbPageComponent implements OnInit {
 
     const tableComponent = this.table();
     if (tableComponent) {
-      tableComponent.setHighlight(query);
+      tableComponent.resetMarkIndex();
       tableComponent.nextResult();
     }
     this.initialSearchQuery = null; // Reset after first use

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -97,13 +97,29 @@ export class AhbPageComponent implements OnInit {
 
     const tableComponent = this.table();
     if (tableComponent) {
-      tableComponent.resetMarkIndex();
       setTimeout(() => {
-        tableComponent.nextResult();
-        tableComponent.scrollToHighlightedElement();
+        tableComponent.resetMarkIndex();
       }, 0);
     }
     this.initialSearchQuery = null; // Reset after first use
+  }
+
+  scrollToElement(element: HTMLElement, offsetY: number): void {
+    const scrollContainer = this.scroll();
+    if (!scrollContainer?.nativeElement) {
+      return;
+    }
+    const containerRect = scrollContainer.nativeElement.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const scrollTop =
+      elementRect.top -
+      containerRect.top +
+      scrollContainer.nativeElement.scrollTop -
+      offsetY;
+    scrollContainer.nativeElement.scrollTo({
+      top: scrollTop,
+      behavior: 'smooth',
+    });
   }
 
   onSearchQueryChange(query: string | undefined) {
@@ -172,23 +188,5 @@ export class AhbPageComponent implements OnInit {
       .split(' an ')
       .map((part) => part.trim());
     return { sender, empfaenger: empfaenger || '' };
-  }
-
-  scrollToElement(element: HTMLElement, offsetY: number): void {
-    const scrollContainer = this.scroll();
-    if (!scrollContainer?.nativeElement) {
-      return;
-    }
-    const containerRect = scrollContainer.nativeElement.getBoundingClientRect();
-    const elementRect = element.getBoundingClientRect();
-    const scrollTop =
-      elementRect.top -
-      containerRect.top +
-      scrollContainer.nativeElement.scrollTop -
-      offsetY;
-    scrollContainer.nativeElement.scrollTo({
-      top: scrollTop,
-      behavior: 'smooth',
-    });
   }
 }


### PR DESCRIPTION
also removes signal writing error in browser console:

```
core.mjs:7191 ERROR RuntimeError: NG0600: Writing to signals is not allowed in a computed or an effect by default. Use allowSignalWrites in the CreateEffectOptions to enable this inside effects. at core.mjs:31536:11 at throwInvalidWriteToSignalError (signals.mjs:398:3) at signalSetFn (signals.mjs:435:5) at signalFn.set (core.mjs:17327:30) at EffectHandle.effectFn (ahb-table.component.ts:56:28) at EffectHandle.runEffect (core.mjs:37282:12) at Object.fn (core.mjs:37277:52) at Object.run (signals.mjs:507:12) at EffectHandle.run (core.mjs:37293:18) at ZoneAwareEffectScheduler.flushQueue (core.mjs:37260:14)
handleError@core.mjs:7191
```