### PR TITLE
fix: rename `getFormatVersion` function to `getFormat`; fix wrong query parameter values in `generateBedingungsbaumDeepLink`

### DIFF
--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
@@ -157,7 +157,7 @@ export class AhbTableComponent {
 
   generateBedingungsbaumDeepLink(expression: string): string {
     const encodedExpression = encodeURIComponent(expression);
-    return `${environment.bedingungsbaumBaseUrl}/tree/?format=${this.formatVersion()}&format_version=${this.getFormat(this.pruefi())}&expression=${encodedExpression}`;
+    return `${environment.bedingungsbaumBaseUrl}/tree/?format=${this.getFormat(this.pruefi())}&format_version=${this.formatVersion()}&expression=${encodedExpression}`;
   }
 
   private getFormat(pruefi: string): string {

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
@@ -157,10 +157,10 @@ export class AhbTableComponent {
 
   generateBedingungsbaumDeepLink(expression: string): string {
     const encodedExpression = encodeURIComponent(expression);
-    return `${environment.bedingungsbaumBaseUrl}/tree/?format=${this.formatVersion()}&format_version=${this.getFormatVersion(this.pruefi())}&expression=${encodedExpression}`;
+    return `${environment.bedingungsbaumBaseUrl}/tree/?format=${this.formatVersion()}&format_version=${this.getFormat(this.pruefi())}&expression=${encodedExpression}`;
   }
 
-  private getFormatVersion(pruefi: string): string {
+  private getFormat(pruefi: string): string {
     const mapping: { [key: string]: string } = {
       '99': 'APERAK',
       '29': 'COMDIS',


### PR DESCRIPTION
because it returns the format and not the version

![{376BE706-4B22-4104-9921-2C2D10100AB1}](https://github.com/user-attachments/assets/2d78cf2f-e599-442e-b2df-c4b16fe825b9)

the link is correct now