### PR TITLE
chore(jest): Fix Jest Deprecation Warnings

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -2,8 +2,8 @@
   "preset": "jest-preset-angular",
   "setupFilesAfterEnv": ["<rootDir>/src/setup-jest.ts"],
   "transform": {
-    "^.+\\.(ts|js|html)$": [
-      "ts-jest",
+    "^.+\\.(ts|html)$": [
+      "jest-preset-angular",
       {
         "tsconfig": "<rootDir>/tsconfig.spec.json",
         "stringifyContentPathRegex": "\\.html$"
@@ -14,8 +14,9 @@
     "^lodash-es$": "lodash"
   },
   "coverageReporters": ["json", "html"],
-  "coverageDirectory": "coverage/api-documentation-portal",
-  "displayName": "ap-ui-example-app",
+  "coverageDirectory": "coverage/ahb-tabellen",
+  "displayName": "ahb-tabellen",
   "modulePathIgnorePatterns": ["<rootDir>/dist"],
-  "transformIgnorePatterns": ["/node_modules/?!@angular"]
+  "transformIgnorePatterns": ["node_modules/(?!.*\\.mjs$|@angular|rxjs)"],
+  "testEnvironment": "jsdom"
 }

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,11 +1,14 @@
 {
   "preset": "jest-preset-angular",
   "setupFilesAfterEnv": ["<rootDir>/src/setup-jest.ts"],
-  "globals": {
-    "ts-jest": {
-      "tsconfig": "<rootDir>/tsconfig.spec.json",
-      "stringifyContentPathRegex": "\\.html$"
-    }
+  "transform": {
+    "^.+\\.(ts|js|html)$": [
+      "ts-jest",
+      {
+        "tsconfig": "<rootDir>/tsconfig.spec.json",
+        "stringifyContentPathRegex": "\\.html$"
+      }
+    ]
   },
   "moduleNameMapper": {
     "^lodash-es$": "lodash"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6433,7 +6433,6 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -12517,7 +12516,6 @@
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
       "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -12693,7 +12691,6 @@
       "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-14.5.1.tgz",
       "integrity": "sha512-HLYYMwNcv3mFrKbOPJwR29tKqVg+yWxez8ilCIsEj1HRYZ/OVsBy5+dcMok+VqL5nmeukTsGnEfGWt+SsQqtkA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "esbuild-wasm": ">=0.15.13",

--- a/src/setup-jest.ts
+++ b/src/setup-jest.ts
@@ -1,1 +1,3 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();


### PR DESCRIPTION
## what is the difference between `jest-preset-angular` and `ts-jest`?

Let me explain the key differences between `jest-preset-angular` and `ts-jest`

### ts-jest

- A general-purpose Jest transformer for TypeScript files
- Converts TypeScript code to JavaScript that Jest can understand
- Provides basic TypeScript support for any Jest project
- Doesn't have any framework-specific handling
- Used as a foundation by many other testing presets

### jest-preset-angular

- Built specifically for testing Angular applications
- Actually uses `ts-jest` under the hood, but adds Angular-specific functionality
- Includes additional features like:
  - Proper handling of Angular templates and decorators
  - Built-in support for Angular's zone.js
  - Handling of Angular's dependency injection system
  - Support for Angular's template syntax
  - Proper transformation of Angular-specific files (like `.html` templates)
  - Preconfigured settings optimized for Angular testing
  - Handles Angular's module system and decorators correctly
 
In our configuration, using `jest-preset-angular` as the transformer is better because:

1. It understands Angular-specific code patterns
2. It handles Angular templates and modules correctly
3. It comes with pre-configured settings that work well with Angular's ecosystem
4. It includes the zone.js setup needed for Angular's change detection

That's why switching from ts-jest to jest-preset-angular in your configuration helped resolve the issues - it provides the complete Angular testing environment rather than just TypeScript compilation.