### PR TITLE
perf(format-version-endpoint): ⚡Read distinct format versions from suited SQLite table (not the `v_ahbtabellen` view)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Create an `.env` file in the root directory and paste the contents of the `.exam
 > This database is stored in an encrypted 7z archive at `src/server/data/ahb.db.encrypted.7z`.
 > You will need the password to decrypt this archive, which can be found in the Hochfrequenz 1Password vault at [this link](https://start.1password.com/open/i?a=F35NURJ4PFGOPBA77PR66C5P4I&v=vjgfwz7dg5wg656rfpvadetrqy&i=grnjb4hn6ipcau4bqe43rkuwnq&h=hochfrequenz.1password.com).
 >
-> If you don't have access to the 1Password vault, please ask your teamates how to get the password.
+> If you don't have access to the 1Password vault, please ask your teammates how to get the password.
 >
 > To work locally, you need to decrypt the archive and store the decrypted file in at `src/server/data/ahb.db`.
 >
@@ -93,6 +93,8 @@ $ docker compose up -d --build
 ```
 
 and navigate to `http://localhost:4000/`.
+
+If this fails to start because of azure-mock problems, just copy the _unencrypted_ database to `src/server/data/ahb.db` and start the Angular CLI server.
 
 ### Starting the app using Angular CLI
 

--- a/src/server/controller/formatVersion.ts
+++ b/src/server/controller/formatVersion.ts
@@ -9,12 +9,7 @@ export default class FormatVersionController {
 
   public async list(_req: Request, res: Response): Promise<void> {
     const formatVersionEntity = await this.repository.list();
-    res
-      .status(200)
-      .setHeader('Content-Type', 'application/json')
-      .setHeader('Cache-Control', 'public, max-age=3600') // Cache for 1 hour
-      .setHeader('ETag', `"${formatVersionEntity.join(',')}"`) // Simple ETag based on content
-      .send(formatVersionEntity);
+    res.status(200).setHeader('Content-Type', 'application/json').send(formatVersionEntity);
   }
 
   public async listPruefisByFormatVersion(req: Request, res: Response): Promise<void> {

--- a/src/server/entities/ahb-line.entity.ts
+++ b/src/server/entities/ahb-line.entity.ts
@@ -5,6 +5,15 @@
 
 import { Entity, Column, PrimaryColumn } from 'typeorm';
 
+@Entity({ name: 'anwendungshandbuch', synchronize: false })
+export class Anwendungshandbuch {
+  // original structure: https://github.com/Hochfrequenz/xml-fundamend-python/blob/f94fbe2bf228f30fc4919abc47d5edc4dd1e3ea5/src/fundamend/sqlmodels/anwendungshandbuch.py#L464-L512
+  @PrimaryColumn({ type: 'varchar', length: 32 })
+  primary_key!: string;
+  // we omit the other columns as they are not relevant to use right now
+  @Column({ type: 'varchar', nullable: true })
+  edifact_format_version?: string;
+}
 @Entity({ name: 'v_ahbtabellen', synchronize: false })
 export class AhbLine {
   @PrimaryColumn({ type: 'varchar', length: 32 })

--- a/src/server/infrastructure/database.ts
+++ b/src/server/infrastructure/database.ts
@@ -1,6 +1,6 @@
 import { DataSource } from 'typeorm';
 import { AhbMetaInformation } from '../entities/ahb-meta-information.entity';
-import {AhbLine, Anwendungshandbuch} from '../entities/ahb-line.entity';
+import { AhbLine, Anwendungshandbuch } from '../entities/ahb-line.entity';
 import path from 'path';
 
 const dbPath = path.resolve(process.cwd(), 'src/server/data/ahb.db');

--- a/src/server/infrastructure/database.ts
+++ b/src/server/infrastructure/database.ts
@@ -1,6 +1,6 @@
 import { DataSource } from 'typeorm';
 import { AhbMetaInformation } from '../entities/ahb-meta-information.entity';
-import { AhbLine } from '../entities/ahb-line.entity';
+import {AhbLine, Anwendungshandbuch} from '../entities/ahb-line.entity';
 import path from 'path';
 
 const dbPath = path.resolve(process.cwd(), 'src/server/data/ahb.db');
@@ -9,7 +9,7 @@ const dbPath = path.resolve(process.cwd(), 'src/server/data/ahb.db');
 const dataSourceConfig = {
   type: 'sqlite' as const,
   database: dbPath,
-  entities: [AhbMetaInformation, AhbLine],
+  entities: [AhbMetaInformation, AhbLine, Anwendungshandbuch],
   logging: true, // Enable SQL query logging
   synchronize: false, // Set to false since we already have the database schema
 };

--- a/src/server/repository/formatVersion.ts
+++ b/src/server/repository/formatVersion.ts
@@ -2,7 +2,7 @@ import { BlobServiceClient, ContainerClient } from '@azure/storage-blob';
 import BlobStorageContainerBacked from './abstract/blobStorageBacked';
 import { NotFoundError } from '../infrastructure/errors';
 import { AppDataSource } from '../infrastructure/database';
-import { AhbLine } from '../entities/ahb-line.entity';
+import { AhbLine, Anwendungshandbuch } from '../entities/ahb-line.entity';
 
 interface FormatVersionsWithPruefis {
   [formatVersion: string]: Set<string>;
@@ -40,10 +40,10 @@ export default class FormatVersionRepository extends BlobStorageContainerBacked 
       await AppDataSource.initialize();
     }
 
-    const formatVersions = await AppDataSource.getRepository(AhbLine)
+    const formatVersions = await AppDataSource.getRepository(Anwendungshandbuch)
       .createQueryBuilder('ahb')
-      .select('DISTINCT ahb.format_version', 'formatVersion')
-      .orderBy('ahb.format_version')
+      .select('DISTINCT ahb.edifact_format_version', 'formatVersion')
+      .orderBy('ahb.edifact_format_version')
       .getRawMany();
 
     return formatVersions.map(result => result.formatVersion);

--- a/src/server/repository/formatVersion.ts
+++ b/src/server/repository/formatVersion.ts
@@ -20,9 +20,6 @@ interface PruefiWithName {
 export default class FormatVersionRepository extends BlobStorageContainerBacked {
   private ahbContainerName: string;
   private formatVersionContainerName: string;
-  private formatVersionsCache: { versions: string[]; timestamp: number } | null = null;
-  private readonly CACHE_TTL = 3600000; // 1 hour in milliseconds
-
   constructor(client?: BlobServiceClient) {
     super(client);
     if (!process.env['AHB_CONTAINER_NAME']) {
@@ -38,14 +35,6 @@ export default class FormatVersionRepository extends BlobStorageContainerBacked 
 
   // Return a list of all unique format versions from the database
   public async list(): Promise<string[]> {
-    // Check if we have a valid cache
-    if (
-      this.formatVersionsCache &&
-      Date.now() - this.formatVersionsCache.timestamp < this.CACHE_TTL
-    ) {
-      return this.formatVersionsCache.versions;
-    }
-
     // Initialize the database connection if not already initialized
     if (!AppDataSource.isInitialized) {
       await AppDataSource.initialize();
@@ -57,15 +46,7 @@ export default class FormatVersionRepository extends BlobStorageContainerBacked 
       .orderBy('ahb.format_version')
       .getRawMany();
 
-    const versions = formatVersions.map(result => result.formatVersion);
-
-    // Update cache
-    this.formatVersionsCache = {
-      versions,
-      timestamp: Date.now(),
-    };
-
-    return versions;
+    return formatVersions.map(result => result.formatVersion);
   }
 
   // Return a list of all pruefis for a specific format version by looking at the json files


### PR DESCRIPTION
reverts #559, thereby fixes #560 
fixes https://github.com/Hochfrequenz/xml-fundamend-python/issues/137

tested it locally: 
![{47AFBA2B-2CC6-4509-ADA2-BAC5BEA85EBD}](https://github.com/user-attachments/assets/cba9831c-f933-454c-bca6-d8a9d395f06d)
