### PR TITLE
chore: replace kohlrahbi with fundamend in "powered by"-footer

### DIFF
--- a/src/app/shared/components/footer/footer.component.html
+++ b/src/app/shared/components/footer/footer.component.html
@@ -34,8 +34,8 @@
             class="ml-1 mr-2 hover:underline font-mono"
             target="_blank"
             rel="noopener noreferrer"
-            href="https://github.com/Hochfrequenz/kohlrahbi"
-            >kohlr_AHB_i</a
+            href="https://github.com/Hochfrequenz/xml-fundamend-python"
+            >fundamend</a
           >
           |
           <a


### PR DESCRIPTION
as the AHB data are no longer based on the machine-readable anwendungshandbuecher scraped with kohlrahbi but the XML AHBs in the SQLite DB created by fundamend