### PR TITLE
fix(pruefi format mapping): Corrects UTILMD values in pruefi mapping

### DIFF
--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
@@ -260,8 +260,8 @@ export class AhbTableComponent {
       '25': 'UTILTS',
       '91': 'CONTRL',
       '92': 'APERAK',
-      '44': 'UTILMD',
-      '55': 'UTILMD',
+      '44': 'UTILMDG',
+      '55': 'UTILMDS',
     };
 
     const key = pruefi.substring(0, 2);


### PR DESCRIPTION
Updates the pruefi mapping to differentiate between UTILMDG and UTILMDS based on the key values '44' and '55' respectively.
