### PR TITLE
feat(tab-title): Updates page title with AHB description

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { ApplicationConfig, importProvidersFrom } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { Title } from '@angular/platform-browser';
 
 import { routes } from './app.routes';
 import { ApiModule } from './core/api';
@@ -16,6 +17,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes, withComponentInputBinding()),
     provideAnimations(),
+    Title,
     importProvidersFrom(
       HttpClientModule,
       ApiModule.forRoot({

--- a/src/app/features/ahbs/views/ahb-landing-page/ahb-landing-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-landing-page/ahb-landing-page.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { FooterComponent } from '../../../../shared/components/footer/footer.component';
 import { SolutionsFooterComponent } from '../../../../shared/components/solutions-footer/solutions-footer.component';
@@ -27,7 +28,7 @@ import { InputSearchEnhancedComponent } from '../../../../shared/components/inpu
   ],
   templateUrl: './ahb-landing-page.component.html',
 })
-export class AhbLandingPageComponent {
+export class AhbLandingPageComponent implements OnInit {
   form = new FormGroup({
     formatVersion: new FormControl<string>('', {
       nonNullable: true,
@@ -36,7 +37,10 @@ export class AhbLandingPageComponent {
     pruefi: new FormControl<string>('', { nonNullable: true, validators: [Validators.required] }),
   });
 
-  constructor(private readonly router: Router) {
+  constructor(
+    private readonly router: Router,
+    private readonly title: Title
+  ) {
     // Subscribe to pruefi value changes
     this.form.controls.pruefi.valueChanges.subscribe(value => {
       // If we have a 5-digit number and a format version, navigate immediately
@@ -44,6 +48,10 @@ export class AhbLandingPageComponent {
         this.onClickSubmit();
       }
     });
+  }
+
+  ngOnInit(): void {
+    this.title.setTitle('AHB-Tabellen - Anwendungshandbücher für Menschen');
   }
 
   onClickSubmit() {

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -96,6 +96,7 @@ export class AhbPageComponent implements OnInit, OnDestroy {
         this.formatVersion.set(formatVersion);
         this.pruefi.set(pruefi);
         this.loadAhbData(formatVersion, pruefi);
+        this.updateTitle({ pruefi, formatVersion });
       }
     });
 

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -18,7 +18,7 @@ import { Ahb, AhbService } from '../../../../core/api';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Observable, Subject, of } from 'rxjs';
-import { map, shareReplay, catchError, takeUntil, distinctUntilChanged } from 'rxjs/operators';
+import { map, shareReplay, catchError, takeUntil, distinctUntilChanged, tap } from 'rxjs/operators';
 import { AhbSearchFormHeaderComponent } from '../../components/ahb-search-form-header/ahb-search-form-header.component';
 import { InputSearchEnhancedComponent } from '../../../../shared/components/input-search-enhanced/input-search-enhanced.component';
 import { ExportButtonComponent } from '../../components/export-button/export-button.component';
@@ -134,6 +134,15 @@ export class AhbPageComponent implements OnInit, OnDestroy {
         pruefi: pruefi,
       })
       .pipe(
+        tap(ahb => {
+          if (ahb && (ahb as Ahb).meta) {
+            this.updateTitle({
+              pruefi,
+              formatVersion,
+              description: (ahb as Ahb).meta.description,
+            });
+          }
+        }),
         shareReplay(1),
         catchError(error => {
           if (error.status === 404) {
@@ -144,27 +153,6 @@ export class AhbPageComponent implements OnInit, OnDestroy {
       );
 
     this.lines$ = this.ahb$.pipe(map(ahb => ahb.lines));
-
-    // Update title once metadata arrives
-    this.ahb$
-      .pipe(
-        map(ahb => ({
-          ahb,
-          pruefi,
-          formatVersion
-        })),
-        takeUntil(this.destroy$)
-      )
-      .subscribe(({ ahb, pruefi, formatVersion }) => {
-        if (!ahb || !ahb.meta) {
-          return;
-        }
-        this.updateTitle({
-          pruefi,
-          formatVersion,
-          description: ahb.meta.description,
-        });
-      });
   }
 
   onFormatVersionChange(newFormatVersion: string) {

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -157,6 +157,19 @@ export class AhbPageComponent implements OnInit, OnDestroy {
     if (!query) return;
   }
 
+  private updateTitle(params: {
+    pruefi: string;
+    formatVersion: string;
+    description?: string;
+  }): void {
+    const { pruefi, formatVersion, description } = params;
+    const appName = 'AHB Tabellen';
+    const base = description ? `${pruefi} – ${description}` : `${pruefi}`;
+    const suffix = formatVersion ? formatVersion : '';
+    const full = [base, suffix, appName].filter(Boolean).join(' | ');
+    this.title.setTitle(full);
+  }
+
   scrollToElement(element: HTMLElement, offsetY: number): void {
     const scrollContainer = this.scroll();
     if (!scrollContainer?.nativeElement) return;

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -144,6 +144,18 @@ export class AhbPageComponent implements OnInit, OnDestroy {
       );
 
     this.lines$ = this.ahb$.pipe(map(ahb => ahb.lines));
+
+    // Update title once metadata arrives
+    this.ahb$.pipe(takeUntil(this.destroy$)).subscribe(ahb => {
+      if (!ahb || !ahb.meta) {
+        return;
+      }
+      this.updateTitle({
+        pruefi,
+        formatVersion,
+        description: ahb.meta.description,
+      });
+    });
   }
 
   onFormatVersionChange(newFormatVersion: string) {

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -187,7 +187,7 @@ export class AhbPageComponent implements OnInit, OnDestroy {
     const { pruefi, formatVersion, description } = params;
     const appName = 'AHB Tabellen';
     const base = description ? `${pruefi} – ${description}` : `${pruefi}`;
-    const suffix = formatVersion ? formatVersion : '';
+    const suffix = formatVersion;
     const full = [base, suffix, appName].filter(Boolean).join(' | ');
     this.title.setTitle(full);
   }

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -146,16 +146,25 @@ export class AhbPageComponent implements OnInit, OnDestroy {
     this.lines$ = this.ahb$.pipe(map(ahb => ahb.lines));
 
     // Update title once metadata arrives
-    this.ahb$.pipe(takeUntil(this.destroy$)).subscribe(ahb => {
-      if (!ahb || !ahb.meta) {
-        return;
-      }
-      this.updateTitle({
-        pruefi,
-        formatVersion,
-        description: ahb.meta.description,
+    this.ahb$
+      .pipe(
+        map(ahb => ({
+          ahb,
+          pruefi,
+          formatVersion
+        })),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(({ ahb, pruefi, formatVersion }) => {
+        if (!ahb || !ahb.meta) {
+          return;
+        }
+        this.updateTitle({
+          pruefi,
+          formatVersion,
+          description: ahb.meta.description,
+        });
       });
-    });
   }
 
   onFormatVersionChange(newFormatVersion: string) {

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -8,6 +8,7 @@ import {
   computed,
 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Title } from '@angular/platform-browser';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { FooterComponent } from '../../../../shared/components/footer/footer.component';
 import { SolutionsFooterComponent } from '../../../../shared/components/solutions-footer/solutions-footer.component';
@@ -80,7 +81,8 @@ export class AhbPageComponent implements OnInit, OnDestroy {
     private readonly ahbService: AhbService,
     private readonly route: ActivatedRoute,
     private readonly router: Router,
-    private readonly http: HttpClient
+    private readonly http: HttpClient,
+    private readonly title: Title
   ) {}
 
   ngOnInit() {

--- a/src/app/features/landingpage/views/landing-page/landing-page.component.ts
+++ b/src/app/features/landingpage/views/landing-page/landing-page.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { AuthService } from '@auth0/auth0-angular';
 import { FooterComponent } from '../../../../shared/components/footer/footer.component';
 import { environment } from '../../../../environments/environment';
-import { Meta } from '@angular/platform-browser';
+import { Meta, Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-landing-page',
@@ -15,12 +15,14 @@ export class LandingPageComponent implements OnInit {
   constructor(
     private auth: AuthService,
     private router: Router,
-    private meta: Meta
+    private meta: Meta,
+    private readonly title: Title
   ) {}
 
   ngOnInit() {
     const baseUrl = environment.baseUrl;
 
+    this.title.setTitle('AHB-Tabellen - Anwendungshandbücher für Menschen');
     this.meta.addTags([
       {
         name: 'description',


### PR DESCRIPTION
Updates the page title to include the AHB description for better user context.

- Provides the Angular `Title` service application-wide.
- Updates the AHB page component to inject and use the `Title` service.
- Implements a helper method to construct the page title based on route parameters and AHB data.
- Sets the initial page title based on route parameters and refines it after the AHB data is loaded.

fix #665
