### PR TITLE
chore: Marks API code as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 CHANGELOG.md linguist-generated=true
+src/app/core/api/**/* linguist-generated=true


### PR DESCRIPTION
Excludes the API code from linguistic analysis
to improve code statistics.

fix #675 
