### PR TITLE
perf(search): simplify `LIKE` search (drop `LOWER(...)` in favour of `COLLATE NOCASE`)

### DIFF
--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -156,17 +156,17 @@ export default class AHBRepository {
           );
         }
         if (value.contains !== undefined) {
-          queryBuilder.andWhere(`al.${columnName} LIKE :${paramBase}_contains`, {
+          queryBuilder.andWhere(`al.${columnName} COLLATE NOCASE LIKE :${paramBase}_contains`, {
             [`${paramBase}_contains`]: `%${value.contains.toLowerCase()}%`,
           });
         }
         if (value.startsWith !== undefined) {
-          queryBuilder.andWhere(`al.${columnName} LIKE :${paramBase}_starts`, {
+          queryBuilder.andWhere(`al.${columnName} COLLATE NOCASE LIKE :${paramBase}_starts`, {
             [`${paramBase}_starts`]: `${value.startsWith.toLowerCase()}%`,
           });
         }
         if (value.endsWith !== undefined) {
-          queryBuilder.andWhere(`al.${columnName} LIKE :${paramBase}_ends`, {
+          queryBuilder.andWhere(`al.${columnName} COLLATE NOCASE LIKE :${paramBase}_ends`, {
             [`${paramBase}_ends`]: `%${value.endsWith.toLowerCase()}`,
           });
         }

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -156,17 +156,17 @@ export default class AHBRepository {
           );
         }
         if (value.contains !== undefined) {
-          queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_contains`, {
+          queryBuilder.andWhere(`al.${columnName} LIKE :${paramBase}_contains`, {
             [`${paramBase}_contains`]: `%${value.contains.toLowerCase()}%`,
           });
         }
         if (value.startsWith !== undefined) {
-          queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_starts`, {
+          queryBuilder.andWhere(`al.${columnName} LIKE :${paramBase}_starts`, {
             [`${paramBase}_starts`]: `${value.startsWith.toLowerCase()}%`,
           });
         }
         if (value.endsWith !== undefined) {
-          queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_ends`, {
+          queryBuilder.andWhere(`al.${columnName} LIKE :${paramBase}_ends`, {
             [`${paramBase}_ends`]: `%${value.endsWith.toLowerCase()}`,
           });
         }


### PR DESCRIPTION
maybe we need to add `COLLATE NOCASE` to the where clause, idk...

see: https://github.com/Hochfrequenz/xml-fundamend-python/pull/193

@hf-krechan : man müsste mal aus dem fundamend-pr eine DB bauen und schauen ob das so funktioniert. ich glaube aber, dass aktuell der index auf der spalte nicht genutzt wird und ohne collate nocase nur für ascii-zeichen genutzt würde (siehe auch die description vom fundanemnd-pr)