### PR TITLE
fix(ui): use regular casing for text input fields (instead of lower case

### DIFF
--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -31,7 +31,7 @@
           *ngIf="field.type === 'text'"
           matInput
           [formControlName]="field.key"
-          [placeholder]="'Filtern nach ' + field.label.toLowerCase()" />
+          [placeholder]="'Filtern nach ' + field.label" />
 
         <button
           mat-icon-button


### PR DESCRIPTION
<img width="333" height="86" alt="{0A8169AE-2263-47F9-846F-E1ADB6DBE3C6}" src="https://github.com/user-attachments/assets/976d5ff4-841c-43d3-92e1-bc82a2f802ed" />

Ich weiß nicht wozu es ursprünglich gedacht war aber zumindest aktuell sieht das komisch aus.