### PR TITLE
chore(global-search): Formats data element in search table

### DIFF
--- a/src/app/features/search/components/search-table/search-table.component.html
+++ b/src/app/features/search/components/search-table/search-table.component.html
@@ -60,8 +60,8 @@
 
     <!-- Data Element Column -->
     <ng-container matColumnDef="data_element">
-      <mat-header-cell *matHeaderCellDef mat-sort-header>Data Element</mat-header-cell>
-      <mat-cell *matCellDef="let row">{{ formatCellValue(row.data_element) }}</mat-cell>
+      <mat-header-cell *matHeaderCellDef mat-sort-header>Datenelement</mat-header-cell>
+      <mat-cell *matCellDef="let row">{{ formatDataElement(row.data_element) }}</mat-cell>
     </ng-container>
 
     <!-- Qualifier Column -->

--- a/src/app/features/search/components/search-table/search-table.component.ts
+++ b/src/app/features/search/components/search-table/search-table.component.ts
@@ -90,6 +90,17 @@ export class SearchTableComponent implements OnChanges {
     return String(value);
   }
 
+  formatDataElement(value: string | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '-';
+    }
+    // Remove "D_" prefix if present
+    if (value.startsWith('D_')) {
+      return value.substring(2);
+    }
+    return value;
+  }
+
   onPruefidentifikatorClick(item: SearchItem): void {
     if (item.format_version && item.pruefidentifikator) {
       const url = this.router


### PR DESCRIPTION
Formats the data element column in the search table by removing the "D_" prefix, if present, to improve readability.
Also translates the column header to German.
