### PR TITLE
feat(search): add wildcard (*) support for global and field searches

### DIFF
--- a/src/server/repository/ahb.spec.ts
+++ b/src/server/repository/ahb.spec.ts
@@ -485,4 +485,78 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
       );
     });
   });
+
+  describe('searchAhbLines with wildcard in contains filter', () => {
+    it('should convert * wildcard to SQL % pattern in contains filter', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: '',
+        filters: {
+          pruefidentifikator: { contains: '44*' },
+        },
+      });
+
+      // Should use "44%" pattern (starts with 44)
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.pruefidentifikator) LIKE'),
+        expect.objectContaining({ f_pruefidentifikator_contains: '44%' })
+      );
+    });
+
+    it('should use substring matching when no wildcards in contains filter', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: '',
+        filters: {
+          pruefidentifikator: { contains: '44' },
+        },
+      });
+
+      // Should use "%44%" pattern (substring match)
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.pruefidentifikator) LIKE'),
+        expect.objectContaining({ f_pruefidentifikator_contains: '%44%' })
+      );
+    });
+
+    it('should escape % and _ characters in contains filter', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: '',
+        filters: {
+          line_name: { contains: '100%_test*' },
+        },
+      });
+
+      // Should escape % as \%, _ as \_, and convert * to %
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.line_name) LIKE'),
+        expect.objectContaining({ f_line_name_contains: '100\\%\\_test%' })
+      );
+    });
+
+    it('should handle pattern matching in middle of contains filter', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: '',
+        filters: {
+          line_name: { contains: 'Konfig*-ID' },
+        },
+      });
+
+      // Should use "konfig%-id" pattern
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.line_name) LIKE'),
+        expect.objectContaining({ f_line_name_contains: 'konfig%-id' })
+      );
+    });
+  });
 });

--- a/src/server/repository/ahb.spec.ts
+++ b/src/server/repository/ahb.spec.ts
@@ -355,4 +355,118 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
       expect(result.total).toBe(1);
     });
   });
+
+  describe('searchAhbLines with wildcard search (q parameter)', () => {
+    it('should convert * wildcard to SQL % pattern for prefix search', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: '44*',
+        filters: {},
+      });
+
+      // Should use "44%" pattern (starts with 44)
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.'),
+        expect.objectContaining({ q0: '44%' })
+      );
+    });
+
+    it('should convert * wildcard to SQL % pattern for suffix search', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: '*foo',
+        filters: {},
+      });
+
+      // Should use "%foo" pattern (ends with foo)
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.'),
+        expect.objectContaining({ q0: '%foo' })
+      );
+    });
+
+    it('should convert * wildcard in middle of search term', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: 'Konfig*-ID',
+        filters: {},
+      });
+
+      // Should use "Konfig%-ID" pattern
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.'),
+        expect.objectContaining({ q0: 'konfig%-id' })
+      );
+    });
+
+    it('should handle multiple wildcards', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: '*foo*bar*',
+        filters: {},
+      });
+
+      // Should convert all * to %
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.'),
+        expect.objectContaining({ q0: '%foo%bar%' })
+      );
+    });
+
+    it('should use substring matching when no wildcards are present (backward compatible)', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: 'foo',
+        filters: {},
+      });
+
+      // Should use "%foo%" pattern (substring match - backward compatible)
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.'),
+        expect.objectContaining({ q0: '%foo%' })
+      );
+    });
+
+    it('should escape existing % characters in user input', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: '100%*',
+        filters: {},
+      });
+
+      // Should escape % as \% and convert * to %
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.'),
+        expect.objectContaining({ q0: '100\\%%' })
+      );
+    });
+
+    it('should handle case-insensitive search with wildcards', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: 'FOO*BAR',
+        filters: {},
+      });
+
+      // Should lowercase the pattern
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.'),
+        expect.objectContaining({ q0: 'foo%bar' })
+      );
+    });
+  });
 });

--- a/src/server/repository/ahb.spec.ts
+++ b/src/server/repository/ahb.spec.ts
@@ -453,6 +453,22 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
       );
     });
 
+    it('should escape underscore characters in user input', async () => {
+      await repository.searchAhbLines({
+        page: 1,
+        pageSize: 25,
+        sort: [],
+        q: 'foo_bar*',
+        filters: {},
+      });
+
+      // Should escape _ as \_ (SQL single char wildcard) and convert * to %
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('LOWER(al.'),
+        expect.objectContaining({ q0: 'foo\\_bar%' })
+      );
+    });
+
     it('should handle case-insensitive search with wildcards', async () => {
       await repository.searchAhbLines({
         page: 1,

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -109,6 +109,8 @@ export default class AHBRepository {
     // - If user enters "*", replace with "%" for SQL wildcard
     // - If no "*" is present, wrap with "%" for implicit substring matching
     // - Escapes SQL LIKE special characters: % and _ (single char wildcard)
+    // IMPORTANT: All LIKE queries using this function must include ESCAPE '\\' clause
+    // for SQLite to recognize the backslash as escape character
     const convertToLikePattern = (input: string): string => {
       if (input.includes('*')) {
         // User explicitly used wildcard - escape SQL special chars, then convert * to %

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -184,12 +184,9 @@ export default class AHBRepository {
           );
         }
         if (value.contains !== undefined) {
-          queryBuilder.andWhere(
-            `LOWER(al.${columnName}) LIKE :${paramBase}_contains ESCAPE '\\\\'`,
-            {
-              [`${paramBase}_contains`]: convertToLikePattern(value.contains),
-            }
-          );
+          queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_contains ESCAPE '\\'`, {
+            [`${paramBase}_contains`]: convertToLikePattern(value.contains),
+          });
         }
         if (value.startsWith !== undefined) {
           queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_starts`, {
@@ -261,9 +258,10 @@ export default class AHBRepository {
         const likePattern = convertToLikePattern(qRaw);
 
         // Use TypeORM's parameterized query methods - validate each field
+        // Include ESCAPE clause for SQLite to recognize backslash as escape character
         const orConditions = qFields.map((field, idx) => {
           const columnName = validateField(field);
-          return `LOWER(al.${columnName}) LIKE :q${idx}`;
+          return `LOWER(al.${columnName}) LIKE :q${idx} ESCAPE '\\'`;
         });
 
         const params = Object.fromEntries(qFields.map((_, idx) => [`q${idx}`, likePattern]));

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -112,11 +112,7 @@ export default class AHBRepository {
     const convertToLikePattern = (input: string): string => {
       if (input.includes('*')) {
         // User explicitly used wildcard - escape SQL special chars, then convert * to %
-        return input
-          .toLowerCase()
-          .replace(/%/g, '\\%')
-          .replace(/_/g, '\\_')
-          .replace(/\*/g, '%');
+        return input.toLowerCase().replace(/%/g, '\\%').replace(/_/g, '\\_').replace(/\*/g, '%');
       }
       // No wildcard - use implicit substring matching (escape special chars first)
       const escaped = input.toLowerCase().replace(/%/g, '\\%').replace(/_/g, '\\_');

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -105,6 +105,24 @@ export default class AHBRepository {
       return field;
     };
 
+    // Helper function to convert user wildcard patterns to SQL LIKE patterns
+    // - If user enters "*", replace with "%" for SQL wildcard
+    // - If no "*" is present, wrap with "%" for implicit substring matching
+    // - Escapes SQL LIKE special characters: % and _ (single char wildcard)
+    const convertToLikePattern = (input: string): string => {
+      if (input.includes('*')) {
+        // User explicitly used wildcard - escape SQL special chars, then convert * to %
+        return input
+          .toLowerCase()
+          .replace(/%/g, '\\%')
+          .replace(/_/g, '\\_')
+          .replace(/\*/g, '%');
+      }
+      // No wildcard - use implicit substring matching (escape special chars first)
+      const escaped = input.toLowerCase().replace(/%/g, '\\%').replace(/_/g, '\\_');
+      return `%${escaped}%`;
+    };
+
     // Helper function to apply filters to a query builder
     // This ensures consistent filtering logic between main query and count query
     const applyFilters = (
@@ -168,16 +186,8 @@ export default class AHBRepository {
           );
         }
         if (value.contains !== undefined) {
-          // Apply wildcard conversion: * becomes %, no wildcard means substring match
-          const containsRaw = value.contains;
-          let containsPattern: string;
-          if (containsRaw.includes('*')) {
-            containsPattern = containsRaw.toLowerCase().replace(/%/g, '\\%').replace(/\*/g, '%');
-          } else {
-            containsPattern = `%${containsRaw.toLowerCase()}%`;
-          }
           queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_contains`, {
-            [`${paramBase}_contains`]: containsPattern,
+            [`${paramBase}_contains`]: convertToLikePattern(value.contains),
           });
         }
         if (value.startsWith !== undefined) {
@@ -247,17 +257,7 @@ export default class AHBRepository {
           'bedingung',
         ];
 
-        // Convert user wildcards (*) to SQL LIKE pattern (%)
-        // If user enters "*", replace with "%" for SQL
-        // If no "*" is present, wrap with "%" for substring matching
-        let likePattern: string;
-        if (qRaw.includes('*')) {
-          // User explicitly used wildcard - replace * with % and escape any literal %
-          likePattern = qRaw.toLowerCase().replace(/%/g, '\\%').replace(/\*/g, '%');
-        } else {
-          // No wildcard - use implicit substring matching
-          likePattern = `%${qRaw.toLowerCase()}%`;
-        }
+        const likePattern = convertToLikePattern(qRaw);
 
         // Use TypeORM's parameterized query methods - validate each field
         const orConditions = qFields.map((field, idx) => {

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -168,8 +168,16 @@ export default class AHBRepository {
           );
         }
         if (value.contains !== undefined) {
+          // Apply wildcard conversion: * becomes %, no wildcard means substring match
+          const containsRaw = value.contains;
+          let containsPattern: string;
+          if (containsRaw.includes('*')) {
+            containsPattern = containsRaw.toLowerCase().replace(/%/g, '\\%').replace(/\*/g, '%');
+          } else {
+            containsPattern = `%${containsRaw.toLowerCase()}%`;
+          }
           queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_contains`, {
-            [`${paramBase}_contains`]: `%${value.contains.toLowerCase()}%`,
+            [`${paramBase}_contains`]: containsPattern,
           });
         }
         if (value.startsWith !== undefined) {
@@ -222,8 +230,9 @@ export default class AHBRepository {
       }
 
       // Global q across the 11 fields (case-insensitive LIKE) - Using TypeORM's parameterized methods
-      const q = (payload.q || '').trim().toLowerCase();
-      if (q.length > 0) {
+      // Supports wildcard search with * (e.g., "44*" matches "4400" but not "21044")
+      const qRaw = (payload.q || '').trim();
+      if (qRaw.length > 0) {
         const qFields = [
           'format_version',
           'format',
@@ -238,13 +247,25 @@ export default class AHBRepository {
           'bedingung',
         ];
 
+        // Convert user wildcards (*) to SQL LIKE pattern (%)
+        // If user enters "*", replace with "%" for SQL
+        // If no "*" is present, wrap with "%" for substring matching
+        let likePattern: string;
+        if (qRaw.includes('*')) {
+          // User explicitly used wildcard - replace * with % and escape any literal %
+          likePattern = qRaw.toLowerCase().replace(/%/g, '\\%').replace(/\*/g, '%');
+        } else {
+          // No wildcard - use implicit substring matching
+          likePattern = `%${qRaw.toLowerCase()}%`;
+        }
+
         // Use TypeORM's parameterized query methods - validate each field
         const orConditions = qFields.map((field, idx) => {
           const columnName = validateField(field);
           return `LOWER(al.${columnName}) LIKE :q${idx}`;
         });
 
-        const params = Object.fromEntries(qFields.map((_, idx) => [`q${idx}`, `%${q}%`]));
+        const params = Object.fromEntries(qFields.map((_, idx) => [`q${idx}`, likePattern]));
         queryBuilder.andWhere(`(${orConditions.join(' OR ')})`, params);
       }
     };

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -184,9 +184,12 @@ export default class AHBRepository {
           );
         }
         if (value.contains !== undefined) {
-          queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_contains`, {
-            [`${paramBase}_contains`]: convertToLikePattern(value.contains),
-          });
+          queryBuilder.andWhere(
+            `LOWER(al.${columnName}) LIKE :${paramBase}_contains ESCAPE '\\\\'`,
+            {
+              [`${paramBase}_contains`]: convertToLikePattern(value.contains),
+            }
+          );
         }
         if (value.startsWith !== undefined) {
           queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_starts`, {


### PR DESCRIPTION
Adds support for using * as a wildcard character in search queries.
The * character is converted to SQL % for LIKE pattern matching.

Wildcard behavior:
- "44*" → "44%" (starts with 44, excludes "21044")
- "*foo" → "%foo" (ends with foo)
- "foo*bar" → "foo%bar" (starts with foo, ends with bar)
- "foo*bar*" → "foo%bar%" (starts with foo, contains bar)
- "*foo*bar*" → "%foo%bar%" (contains foo followed by bar)
- "Konfig*-ID" → "konfig%-id" (pattern matching in middle)

Backward compatible behavior (no wildcard):
- "foo" → "%foo%" (substring match, same as before)
- "44" → "%44%" (matches "44", "4400", "21044")

Special character handling:
- Literal % characters in user input are escaped as \%
- "100%*" → "100\%%" (starts with literal "100%")

Applied to both:
- Global search (q parameter)
- Individual field filters (contains)

Fixes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
