### PR TITLE
style(comparison): use mat-spinner for consistent loading indicator

### DIFF
--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.html
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.html
@@ -85,8 +85,7 @@
         }
       } @else {
         <div class="text-center py-12">
-          <div
-            class="animate-spin rounded-full h-12 w-12 border-b-2 border-hf-dunkel-rose mx-auto"></div>
+          <mat-spinner diameter="40" class="mx-auto"></mat-spinner>
           <p class="mt-4 text-gray-500">Lade Vergleich...</p>
         </div>
       }

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.ts
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { Subject, Observable, of, combineLatest } from 'rxjs';
 import { takeUntil, catchError, shareReplay, map } from 'rxjs/operators';
 import { Title } from '@angular/platform-browser';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { FooterComponent } from '../../../../shared/components/footer/footer.component';
@@ -38,6 +39,7 @@ export interface DiffDescription {
     SolutionsFooterComponent,
     ComparisonTableComponent,
     ComparisonSearchFormHeaderComponent,
+    MatProgressSpinnerModule,
   ],
   templateUrl: './comparison-page.component.html',
 })


### PR DESCRIPTION
Replace CSS-based spinner with Angular Material mat-spinner to match
the loading indicator style used in the search page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
