### PR TITLE
fix(comparison): validate pruefi exists in both format versions before comparison

### DIFF
--- a/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.html
+++ b/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.html
@@ -40,4 +40,9 @@
     class="inline-block h-16 w-64"
     formControlName="pruefi"
     [formatVersion]="formatVersionForPruefi" />
+
+  <!-- Validation Spinner -->
+  @if (isValidating()) {
+    <mat-spinner diameter="24"></mat-spinner>
+  }
 </form>

--- a/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.spec.ts
+++ b/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.spec.ts
@@ -3,7 +3,7 @@ import { ComparisonSearchFormHeaderComponent } from './comparison-search-form-he
 import { FormatVersionCacheService } from '../../../search/services/format-version-cache.service';
 import { PrufidentifikatorenService } from '../../../../core/api';
 import { Router } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
@@ -341,6 +341,24 @@ describe('ComparisonSearchFormHeaderComponent', () => {
       // After tick, validation should complete
       tick();
       expect(component.isValidating()).toBe(false);
+    }));
+
+    it('should handle API errors gracefully', fakeAsync(() => {
+      // Mock API to throw an error
+      mockPrufidentifikatorenService.getPruefis.mockReturnValue(
+        throwError(() => new Error('API Error'))
+      );
+
+      fixture.detectChanges();
+      tick();
+
+      component.headerSearchForm.controls.pruefi.setValue('12345');
+      fixture.detectChanges();
+      tick();
+
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+      expect(component.isValidating()).toBe(false);
+      expect(component.validationError()).toBe('Ein Fehler ist bei der Validierung aufgetreten.');
     }));
   });
 });

--- a/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.spec.ts
+++ b/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ComparisonSearchFormHeaderComponent } from './comparison-search-form-header.component';
 import { FormatVersionCacheService } from '../../../search/services/format-version-cache.service';
+import { PrufidentifikatorenService } from '../../../../core/api';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -11,14 +12,24 @@ describe('ComparisonSearchFormHeaderComponent', () => {
   let component: ComparisonSearchFormHeaderComponent;
   let fixture: ComponentFixture<ComparisonSearchFormHeaderComponent>;
   let mockFormatVersionCacheService: jest.Mocked<FormatVersionCacheService>;
+  let mockPrufidentifikatorenService: jest.Mocked<PrufidentifikatorenService>;
   let mockRouter: jest.Mocked<Router>;
 
   const mockVersions = ['FV2304', 'FV2310', 'FV2404', 'FV2410', 'FV2504'];
+  const mockPruefis = [
+    { pruefidentifikator: '11001', name: 'Test Pruefi 1' },
+    { pruefidentifikator: '12345', name: 'Test Pruefi 2' },
+    { pruefidentifikator: '11042', name: 'Test Pruefi 3' },
+  ];
 
   beforeEach(async () => {
     mockFormatVersionCacheService = {
       getFormatVersions: jest.fn().mockReturnValue(of(mockVersions)),
     } as unknown as jest.Mocked<FormatVersionCacheService>;
+
+    mockPrufidentifikatorenService = {
+      getPruefis: jest.fn().mockReturnValue(of(mockPruefis)),
+    } as unknown as jest.Mocked<PrufidentifikatorenService>;
 
     mockRouter = {
       navigate: jest.fn(),
@@ -30,6 +41,7 @@ describe('ComparisonSearchFormHeaderComponent', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         { provide: FormatVersionCacheService, useValue: mockFormatVersionCacheService },
+        { provide: PrufidentifikatorenService, useValue: mockPrufidentifikatorenService },
         { provide: Router, useValue: mockRouter },
       ],
     }).compileComponents();
@@ -197,10 +209,18 @@ describe('ComparisonSearchFormHeaderComponent', () => {
       // Verify navigateOnSubmit is true by default
       expect(component.navigateOnSubmit()).toBe(true);
 
-      // Set pruefi value - this should trigger navigation
+      // Set pruefi value - this should trigger validation and then navigation
       component.headerSearchForm.controls.pruefi.setValue('12345');
       fixture.detectChanges();
       tick();
+
+      // Validation should have been called for both format versions
+      expect(mockPrufidentifikatorenService.getPruefis).toHaveBeenCalledWith({
+        'format-version': 'FV2410',
+      });
+      expect(mockPrufidentifikatorenService.getPruefis).toHaveBeenCalledWith({
+        'format-version': 'FV2504',
+      });
 
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/compare', '12345'], {
         queryParams: {
@@ -230,6 +250,97 @@ describe('ComparisonSearchFormHeaderComponent', () => {
       tick();
 
       expect(mockRouter.navigate).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('pruefi validation', () => {
+    it('should show error when pruefi does not exist in either format version', fakeAsync(() => {
+      // Mock empty pruefi lists for both versions
+      mockPrufidentifikatorenService.getPruefis.mockReturnValue(of([]));
+
+      fixture.detectChanges();
+      tick();
+
+      // Set pruefi value that doesn't exist
+      component.headerSearchForm.controls.pruefi.setValue('99999');
+      fixture.detectChanges();
+      tick();
+
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+      expect(component.validationError()).toContain('weder');
+      expect(component.validationError()).toContain('FV2410');
+      expect(component.validationError()).toContain('FV2504');
+    }));
+
+    it('should show error when pruefi does not exist in old format version only', fakeAsync(() => {
+      // Mock pruefi exists in new version but not in old
+      mockPrufidentifikatorenService.getPruefis.mockImplementation(params => {
+        if (params['format-version'] === 'FV2504') {
+          return of([{ pruefidentifikator: '12345', name: 'Test' }]);
+        }
+        return of([]);
+      });
+
+      fixture.detectChanges();
+      tick();
+
+      component.headerSearchForm.controls.pruefi.setValue('12345');
+      fixture.detectChanges();
+      tick();
+
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+      expect(component.validationError()).toContain('FV2410');
+      expect(component.validationError()).not.toContain('weder');
+    }));
+
+    it('should show error when pruefi does not exist in new format version only', fakeAsync(() => {
+      // Mock pruefi exists in old version but not in new
+      mockPrufidentifikatorenService.getPruefis.mockImplementation(params => {
+        if (params['format-version'] === 'FV2410') {
+          return of([{ pruefidentifikator: '12345', name: 'Test' }]);
+        }
+        return of([]);
+      });
+
+      fixture.detectChanges();
+      tick();
+
+      component.headerSearchForm.controls.pruefi.setValue('12345');
+      fixture.detectChanges();
+      tick();
+
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+      expect(component.validationError()).toContain('FV2504');
+      expect(component.validationError()).not.toContain('weder');
+    }));
+
+    it('should clear validation error when pruefi exists in both versions', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+
+      // Set a pruefi that exists in mock data
+      component.headerSearchForm.controls.pruefi.setValue('12345');
+      fixture.detectChanges();
+      tick();
+
+      expect(component.validationError()).toBeNull();
+      expect(mockRouter.navigate).toHaveBeenCalled();
+    }));
+
+    it('should set isValidating while validation is in progress', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+
+      // Initially not validating
+      expect(component.isValidating()).toBe(false);
+
+      // Start validation
+      component.headerSearchForm.controls.pruefi.setValue('12345');
+      fixture.detectChanges();
+
+      // After tick, validation should complete
+      tick();
+      expect(component.isValidating()).toBe(false);
     }));
   });
 });

--- a/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.spec.ts
+++ b/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.spec.ts
@@ -360,5 +360,44 @@ describe('ComparisonSearchFormHeaderComponent', () => {
       expect(component.isValidating()).toBe(false);
       expect(component.validationError()).toBe('Ein Fehler ist bei der Validierung aufgetreten.');
     }));
+
+    it('should emit validationErrorChange when validation error occurs', fakeAsync(() => {
+      // Mock empty pruefi lists for both versions
+      mockPrufidentifikatorenService.getPruefis.mockReturnValue(of([]));
+
+      fixture.detectChanges();
+      tick();
+
+      const validationErrorChangeSpy = jest.fn();
+      component.validationErrorChange.subscribe(validationErrorChangeSpy);
+
+      // Set pruefi value that doesn't exist
+      component.headerSearchForm.controls.pruefi.setValue('99999');
+      fixture.detectChanges();
+      tick();
+
+      // Should emit null first (clearing previous error), then the error message
+      expect(validationErrorChangeSpy).toHaveBeenCalledWith(null);
+      expect(validationErrorChangeSpy).toHaveBeenCalledWith(expect.stringContaining('weder'));
+    }));
+
+    it('should emit validationErrorChange with null when validation succeeds', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+
+      const validationErrorChangeSpy = jest.fn();
+      component.validationErrorChange.subscribe(validationErrorChangeSpy);
+
+      // Set a pruefi that exists in mock data
+      component.headerSearchForm.controls.pruefi.setValue('12345');
+      fixture.detectChanges();
+      tick();
+
+      // Should emit null (clearing any previous error)
+      expect(validationErrorChangeSpy).toHaveBeenCalledWith(null);
+      // Should not emit any error message
+      expect(validationErrorChangeSpy).not.toHaveBeenCalledWith(expect.stringContaining('Fehler'));
+      expect(validationErrorChangeSpy).not.toHaveBeenCalledWith(expect.stringContaining('weder'));
+    }));
   });
 });

--- a/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.ts
+++ b/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, effect, signal } from '@angular/core';
+import { Component, DestroyRef, inject, input, output, effect, signal } from '@angular/core';
 import {
   FormControl,
   FormGroup,
@@ -28,6 +28,8 @@ import { forkJoin, map } from 'rxjs';
   templateUrl: './comparison-search-form-header.component.html',
 })
 export class ComparisonSearchFormHeaderComponent {
+  private readonly destroyRef = inject(DestroyRef);
+
   formatVersionOld = input<string>('');
   formatVersionNew = input<string>('');
   pruefi = input<string>('');
@@ -177,47 +179,49 @@ export class ComparisonSearchFormHeaderComponent {
       newVersionPruefis: this.prufidentifikatorenService
         .getPruefis({ 'format-version': fvNew })
         .pipe(map(pruefis => pruefis.map(p => p.pruefidentifikator))),
-    }).subscribe({
-      next: ({ oldVersionPruefis, newVersionPruefis }) => {
-        this.isValidating.set(false);
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: ({ oldVersionPruefis, newVersionPruefis }) => {
+          this.isValidating.set(false);
 
-        const existsInOld = oldVersionPruefis.includes(pruefi);
-        const existsInNew = newVersionPruefis.includes(pruefi);
+          const existsInOld = oldVersionPruefis.includes(pruefi);
+          const existsInNew = newVersionPruefis.includes(pruefi);
 
-        if (!existsInOld && !existsInNew) {
-          this.setValidationError(
-            `Der Prüfidentifikator ${pruefi} ist weder in der Formatversion ${fvOld} noch in der ${fvNew} vorhanden.`
-          );
-          return;
-        }
+          if (!existsInOld && !existsInNew) {
+            this.setValidationError(
+              `Der Prüfidentifikator ${pruefi} ist weder in der Formatversion ${fvOld} noch in der ${fvNew} vorhanden.`
+            );
+            return;
+          }
 
-        if (!existsInOld) {
-          this.setValidationError(
-            `Der Prüfidentifikator ${pruefi} konnte nicht in der Formatversion ${fvOld} gefunden werden.`
-          );
-          return;
-        }
+          if (!existsInOld) {
+            this.setValidationError(
+              `Der Prüfidentifikator ${pruefi} konnte nicht in der Formatversion ${fvOld} gefunden werden.`
+            );
+            return;
+          }
 
-        if (!existsInNew) {
-          this.setValidationError(
-            `Der Prüfidentifikator ${pruefi} konnte nicht in der Formatversion ${fvNew} gefunden werden.`
-          );
-          return;
-        }
+          if (!existsInNew) {
+            this.setValidationError(
+              `Der Prüfidentifikator ${pruefi} konnte nicht in der Formatversion ${fvNew} gefunden werden.`
+            );
+            return;
+          }
 
-        // Both versions have the pruefi, navigate
-        this.router.navigate(['/compare', pruefi], {
-          queryParams: {
-            'fv-old': fvOld,
-            'fv-new': fvNew,
-          },
-        });
-      },
-      error: () => {
-        this.isValidating.set(false);
-        this.setValidationError('Ein Fehler ist bei der Validierung aufgetreten.');
-      },
-    });
+          // Both versions have the pruefi, navigate
+          this.router.navigate(['/compare', pruefi], {
+            queryParams: {
+              'fv-old': fvOld,
+              'fv-new': fvNew,
+            },
+          });
+        },
+        error: () => {
+          this.isValidating.set(false);
+          this.setValidationError('Ein Fehler ist bei der Validierung aufgetreten.');
+        },
+      });
   }
 
   private setValidationError(error: string | null): void {

--- a/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.ts
+++ b/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.ts
@@ -171,7 +171,11 @@ export class ComparisonSearchFormHeaderComponent {
     this.setValidationError(null);
     this.isValidating.set(true);
 
-    // Check if pruefi exists in both format versions
+    // Check if pruefi exists in both format versions.
+    // Note: We fetch the full pruefi lists rather than using a dedicated existsPruefi() endpoint
+    // because no such endpoint currently exists in the API. The pruefi lists are relatively small
+    // (~200-300 entries per format version) and are likely already cached by the browser from
+    // the pruefi-input autocomplete, so the performance impact is minimal.
     forkJoin({
       oldVersionPruefis: this.prufidentifikatorenService
         .getPruefis({ 'format-version': fvOld })

--- a/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.ts
+++ b/src/app/features/comparison/components/comparison-search-form-header/comparison-search-form-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, effect } from '@angular/core';
+import { Component, input, output, effect, signal } from '@angular/core';
 import {
   FormControl,
   FormGroup,
@@ -11,11 +11,20 @@ import { PruefiInputComponent } from '../../../ahbs/components/pruefi-input/prue
 import { FormatVersionCacheService } from '../../../search/services/format-version-cache.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { PrufidentifikatorenService } from '../../../../core/api';
+import { forkJoin, map } from 'rxjs';
 
 @Component({
   selector: 'app-comparison-search-form-header',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, PruefiInputComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    PruefiInputComponent,
+    MatProgressSpinnerModule,
+  ],
   templateUrl: './comparison-search-form-header.component.html',
 })
 export class ComparisonSearchFormHeaderComponent {
@@ -27,8 +36,11 @@ export class ComparisonSearchFormHeaderComponent {
   formatVersionOldChange = output<string>();
   formatVersionNewChange = output<string>();
   pruefiChange = output<string>();
+  validationErrorChange = output<string | null>();
 
   formatVersions: string[] = [];
+  validationError = signal<string | null>(null);
+  isValidating = signal<boolean>(false);
 
   headerSearchForm = new FormGroup({
     formatVersionOld: new FormControl('', Validators.required),
@@ -59,7 +71,8 @@ export class ComparisonSearchFormHeaderComponent {
 
   constructor(
     private readonly router: Router,
-    private readonly formatVersionCacheService: FormatVersionCacheService
+    private readonly formatVersionCacheService: FormatVersionCacheService,
+    private readonly prufidentifikatorenService: PrufidentifikatorenService
   ) {
     // Load format versions
     this.formatVersionCacheService
@@ -148,12 +161,67 @@ export class ComparisonSearchFormHeaderComponent {
 
     // Navigate if we have all required values (pruefi must be 5 digits)
     if (pruefi?.match(/^\d{5}$/) && fvOld && fvNew) {
-      this.router.navigate(['/compare', pruefi], {
-        queryParams: {
-          'fv-old': fvOld,
-          'fv-new': fvNew,
-        },
-      });
+      this.validateAndNavigate(pruefi, fvOld, fvNew);
     }
+  }
+
+  private validateAndNavigate(pruefi: string, fvOld: string, fvNew: string): void {
+    this.setValidationError(null);
+    this.isValidating.set(true);
+
+    // Check if pruefi exists in both format versions
+    forkJoin({
+      oldVersionPruefis: this.prufidentifikatorenService
+        .getPruefis({ 'format-version': fvOld })
+        .pipe(map(pruefis => pruefis.map(p => p.pruefidentifikator))),
+      newVersionPruefis: this.prufidentifikatorenService
+        .getPruefis({ 'format-version': fvNew })
+        .pipe(map(pruefis => pruefis.map(p => p.pruefidentifikator))),
+    }).subscribe({
+      next: ({ oldVersionPruefis, newVersionPruefis }) => {
+        this.isValidating.set(false);
+
+        const existsInOld = oldVersionPruefis.includes(pruefi);
+        const existsInNew = newVersionPruefis.includes(pruefi);
+
+        if (!existsInOld && !existsInNew) {
+          this.setValidationError(
+            `Der Prüfidentifikator ${pruefi} ist weder in der Formatversion ${fvOld} noch in der ${fvNew} vorhanden.`
+          );
+          return;
+        }
+
+        if (!existsInOld) {
+          this.setValidationError(
+            `Der Prüfidentifikator ${pruefi} konnte nicht in der Formatversion ${fvOld} gefunden werden.`
+          );
+          return;
+        }
+
+        if (!existsInNew) {
+          this.setValidationError(
+            `Der Prüfidentifikator ${pruefi} konnte nicht in der Formatversion ${fvNew} gefunden werden.`
+          );
+          return;
+        }
+
+        // Both versions have the pruefi, navigate
+        this.router.navigate(['/compare', pruefi], {
+          queryParams: {
+            'fv-old': fvOld,
+            'fv-new': fvNew,
+          },
+        });
+      },
+      error: () => {
+        this.isValidating.set(false);
+        this.setValidationError('Ein Fehler ist bei der Validierung aufgetreten.');
+      },
+    });
+  }
+
+  private setValidationError(error: string | null): void {
+    this.validationError.set(error);
+    this.validationErrorChange.emit(error);
   }
 }

--- a/src/app/features/comparison/views/comparison-landing-page/comparison-landing-page.component.html
+++ b/src/app/features/comparison/views/comparison-landing-page/comparison-landing-page.component.html
@@ -10,7 +10,8 @@
       [pruefi]="pruefiControl.value || ''"
       (formatVersionOldChange)="formatVersionOld.set($event)"
       (formatVersionNewChange)="formatVersionNew.set($event)"
-      (pruefiChange)="pruefiControl.setValue($event)" />
+      (pruefiChange)="pruefiControl.setValue($event)"
+      (validationErrorChange)="onValidationError($event)" />
     <app-input-search-enhanced
       slot="search"
       class="inline-block w-full md:w-96 pointer-events-none opacity-50"
@@ -27,7 +28,8 @@
       [pruefi]="pruefiControl.value || ''"
       (formatVersionOldChange)="formatVersionOld.set($event)"
       (formatVersionNewChange)="formatVersionNew.set($event)"
-      (pruefiChange)="pruefiControl.setValue($event)" />
+      (pruefiChange)="pruefiControl.setValue($event)"
+      (validationErrorChange)="onValidationError($event)" />
     <app-input-search-enhanced
       slot="search-mobile"
       class="w-full"
@@ -56,32 +58,43 @@
           </div>
         </div>
 
+        <!-- Validation Error -->
+        @if (validationError()) {
+          <div
+            class="text-center p-8 bg-hf-grell-rose text-hf-weiches-schwarz rounded-lg mb-6 shadow-sm">
+            <h2 class="text-2xl font-bold mb-4">Fehler</h2>
+            <p class="mb-4">{{ validationError() }}</p>
+          </div>
+        }
+
         <!-- Info box -->
-        <div class="bg-white rounded-lg p-4 md:p-6 mb-6 shadow-sm">
-          <div class="flex items-start space-x-3">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              class="w-6 h-6 text-hf-dunkel-rose flex-shrink-0 mt-0.5">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
-            </svg>
-            <div>
-              <p class="text-sm md:text-base text-hf-weiches-schwarz font-medium">
-                Prüfidentifikator angeben
-              </p>
-              <p class="text-sm text-hf-weiches-schwarz mt-1 opacity-75">
-                Wählen Sie zwei Formatversionen aus und geben Sie einen Prüfidentifikator ein, um
-                die Änderungen zwischen den Versionen zu visualisieren.
-              </p>
+        @if (!validationError()) {
+          <div class="bg-white rounded-lg p-4 md:p-6 mb-6 shadow-sm">
+            <div class="flex items-start space-x-3">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                class="w-6 h-6 text-hf-dunkel-rose flex-shrink-0 mt-0.5">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+              </svg>
+              <div>
+                <p class="text-sm md:text-base text-hf-weiches-schwarz font-medium">
+                  Prüfidentifikator angeben
+                </p>
+                <p class="text-sm text-hf-weiches-schwarz mt-1 opacity-75">
+                  Wählen Sie zwei Formatversionen aus und geben Sie einen Prüfidentifikator ein, um
+                  die Änderungen zwischen den Versionen zu visualisieren.
+                </p>
+              </div>
             </div>
           </div>
-        </div>
+        }
       </div>
     </div>
   </div>

--- a/src/app/features/comparison/views/comparison-landing-page/comparison-landing-page.component.ts
+++ b/src/app/features/comparison/views/comparison-landing-page/comparison-landing-page.component.ts
@@ -28,10 +28,15 @@ export class ComparisonLandingPageComponent implements OnInit {
   pruefiControl = new FormControl<string>('');
   formatVersionOld = signal<string>('');
   formatVersionNew = signal<string>('');
+  validationError = signal<string | null>(null);
 
   constructor(private readonly title: Title) {}
 
   ngOnInit(): void {
     this.title.setTitle('AHB Vergleich - Formatversionen vergleichen');
+  }
+
+  onValidationError(error: string | null): void {
+    this.validationError.set(error);
   }
 }

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.html
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.html
@@ -68,7 +68,15 @@
       <div
         class="text-center p-8 bg-hf-grell-rose text-hf-weiches-schwarz rounded-lg max-w-4xl mx-auto">
         <h2 class="text-2xl font-bold mb-4">Fehler</h2>
-        <p class="mb-4">{{ errorMessage }}</p>
+        @if (errorDetails(); as details) {
+          <p class="mb-4">
+            Prüfidentifikator <strong>{{ details.pruefi }}</strong> in beiden Formatversionen
+            <strong>{{ details.fvNew }}</strong> und <strong>{{ details.fvOld }}</strong> nicht
+            gefunden.
+          </p>
+        } @else {
+          <p class="mb-4">{{ errorMessage }}</p>
+        }
       </div>
     } @else {
       @if (diff$ | async; as diff) {

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.ts
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.ts
@@ -146,10 +146,17 @@ export class ComparisonPageComponent implements OnInit, OnDestroy {
         shareReplay(1),
         catchError(error => {
           this.errorOccurred = true;
-          this.errorMessage =
-            error.status === 404
-              ? `Prüfidentifikator ${this.pruefi()} nicht in beiden Formatversionen gefunden.`
-              : 'Ein Fehler ist aufgetreten.';
+          if (error.status === 404) {
+            this.errorDetails.set({
+              pruefi: this.pruefi(),
+              fvNew: this.formatVersionNew(),
+              fvOld: this.formatVersionOld(),
+            });
+            this.errorMessage = '';
+          } else {
+            this.errorDetails.set(null);
+            this.errorMessage = 'Ein Fehler ist aufgetreten.';
+          }
           return of({} as AhbDiff);
         })
       );

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.ts
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.ts
@@ -53,6 +53,7 @@ export class ComparisonPageComponent implements OnInit, OnDestroy {
   description$?: Observable<DiffDescription>;
   errorOccurred = false;
   errorMessage = '';
+  errorDetails = signal<{ pruefi: string; fvNew: string; fvOld: string } | null>(null);
 
   private destroy$ = new Subject<void>();
 
@@ -132,6 +133,7 @@ export class ComparisonPageComponent implements OnInit, OnDestroy {
   private loadDiff(): void {
     this.errorOccurred = false;
     this.errorMessage = '';
+    this.errorDetails.set(null);
     this.updateTitle();
 
     this.diff$ = this.ahbService


### PR DESCRIPTION
Before starting a comparison, the application now validates that the
entered Prüfidentifikator exists in both the old and new format versions.
This prevents the page from freezing while making API calls that would
fail for invalid pruefis.

The validation checks both format versions in parallel and displays
specific error messages:
- If not found in either: "Der Prüfidentifikator X ist weder in der
  Formatversion Y noch in der Z vorhanden."
- If not found in old version only: "Der Prüfidentifikator X konnte
  nicht in der Formatversion Y gefunden werden."
- If not found in new version only: "Der Prüfidentifikator X konnte
  nicht in der Formatversion Z gefunden werden."

Error messages are displayed centrally on the page, matching the existing
error display pattern used elsewhere in the application.

fixes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
