### PR TITLE
feat(version): add commitDate to /version endpoint

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(findstr:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(npx prettier:*)"
+      "Bash(npx prettier:*)",
+      "Skill(superpowers:brainstorming)"
     ],
     "deny": [],
     "ask": []

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   BUILD_DATE: 'set by build_release_info step'
+  COMMIT_DATE: 'set by build_release_info step'
   COMMIT_ID: 'set by build_release_info step'
   VERSION_TAG: 'set by build_release_info step'
   DOCKER_TAG: 'set by extract-tag step'
@@ -56,9 +57,11 @@ jobs:
         id: build_release_info
         run: |
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          COMMIT_DATE=$(git log -1 --format='%cI')
           COMMIT_ID=$(git rev-parse HEAD)
           VERSION_TAG=${GITHUB_REF#refs/tags/}
           echo "BUILD_DATE=$BUILD_DATE" >> $GITHUB_ENV
+          echo "COMMIT_DATE=$COMMIT_DATE" >> $GITHUB_ENV
           echo "COMMIT_ID=$COMMIT_ID" >> $GITHUB_ENV
           echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
 
@@ -108,6 +111,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
+            COMMIT_DATE=${{ env.COMMIT_DATE }}
             COMMIT_ID=${{ env.COMMIT_ID }}
             VERSION=${{ env.VERSION_TAG }}
 
@@ -140,9 +144,11 @@ jobs:
         id: build_release_info
         run: |
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          COMMIT_DATE=$(git log -1 --format='%cI')
           COMMIT_ID=$(git rev-parse HEAD)
           VERSION_TAG=${GITHUB_REF#refs/tags/}
           echo "BUILD_DATE=$BUILD_DATE" >> $GITHUB_ENV
+          echo "COMMIT_DATE=$COMMIT_DATE" >> $GITHUB_ENV
           echo "COMMIT_ID=$COMMIT_ID" >> $GITHUB_ENV
           echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
 
@@ -182,6 +188,7 @@ jobs:
           fi
           echo "Extracted Docker tag: $DOCKER_TAG"
           echo "tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image for Production
         id: push
         uses: docker/build-push-action@v6.18.0
@@ -192,6 +199,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
+            COMMIT_DATE=${{ env.COMMIT_DATE }}
             COMMIT_ID=${{ env.COMMIT_ID }}
             VERSION=${{ env.VERSION_TAG }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ Thumbs.db
 
 
 src/server/data/ahb.db
+
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ FROM node:25.2-alpine
 
 # Set environment arguments and variables
 ARG BUILD_DATE
+ARG COMMIT_DATE
 ARG COMMIT_ID
 ARG VERSION
 
 # Environment variables
 ENV BUILD_DATE=$BUILD_DATE \
+  COMMIT_DATE=$COMMIT_DATE \
   COMMIT_ID=$COMMIT_ID \
   VERSION=$VERSION
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         BUILD_DATE: dummy
+        COMMIT_DATE: dummy
         COMMIT_ID: wip
         VERSION: v0.0.0-local
     ports:

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ AppDataSource.initialize()
 server.get('/version', (_, res) =>
   res.send({
     buildDate: process.env['BUILD_DATE'] || 'unknown',
+    commitDate: process.env['COMMIT_DATE'] || 'unknown',
     commitId: process.env['COMMIT_ID'] || 'unknown',
     version: process.env['VERSION'] || 'unknown',
     environment: process.env['ENVIRONMENT'] || 'unknown (local)',


### PR DESCRIPTION
Add the git commit timestamp as a separate field in the /version endpoint
response, distinct from the build timestamp.

Investigation findings:
- The existing BUILD_DATE was already correctly set to the actual build
  time using $(date -u) in the workflow, NOT the commit time as initially
  reported in issue #739
- The real issue was that commitDate was missing from the response entirely
- The openapi.yml and API models already had commitDate defined but it was
  never populated

Changes:
- deploy.yml: Extract COMMIT_DATE using git log -1 --format='%cI' (ISO 8601
  format) and pass it as a Docker build arg in both stage and production jobs
- Dockerfile: Add COMMIT_DATE build arg and environment variable
- docker-compose.yaml: Add COMMIT_DATE for local development
- server.ts: Expose commitDate in the /version endpoint response

The /version endpoint now returns both:
- buildDate: when the Docker image was built (workflow execution time)
- commitDate: when the commit was created (git commit timestamp)

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
