### PR TITLE
refactor: extract pruefi-to-format mapping to shared utility

### DIFF
--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
@@ -14,6 +14,7 @@ import { HighlightPipe, HighlightResult } from '../../../../shared/pipes/highlig
 import { environment } from '../../../../environments/environment';
 import { IconLinkComponent } from '../../../../shared/components/icon-link/icon-link.component';
 import { DomSanitizer } from '@angular/platform-browser';
+import { getFormatFromPruefi } from '../../../../shared/utils/pruefi-format.utils';
 
 interface ExpandedState {
   [key: number]: boolean;
@@ -236,7 +237,7 @@ export class AhbTableComponent {
 
   generateBedingungsbaumDeepLink(expression: string): string {
     const encodedExpression = encodeURIComponent(expression);
-    return `${environment.bedingungsbaumBaseUrl}/tree/?format=${this.getFormat(this.pruefi())}&format_version=${this.formatVersion()}&expression=${encodedExpression}`;
+    return `${environment.bedingungsbaumBaseUrl}/tree/?format=${getFormatFromPruefi(this.pruefi())}&format_version=${this.formatVersion()}&expression=${encodedExpression}`;
   }
 
   generateEbdDeepLink(value_pool_entry: string | null): string | null {
@@ -251,34 +252,6 @@ export class AhbTableComponent {
     const ebdKey = match.groups['ebd_key']!;
     // e.g. https://ebd.stage.hochfrequenz.de/ebd/?formatversion=FV2504&ebd=E_0004
     return `${environment.ebdBaseUrl}/ebd/?formatversion=${this.formatVersion()}&ebd=${ebdKey}`;
-  }
-
-  private getFormat(pruefi: string): string {
-    const mapping: { [key: string]: string } = {
-      '99': 'APERAK',
-      '29': 'COMDIS',
-      '21': 'IFTSTA',
-      '23': 'INSRPT',
-      '31': 'INVOIC',
-      '13': 'MSCONS',
-      '39': 'ORDCHG',
-      '17': 'ORDERS',
-      '19': 'ORDRSP',
-      '27': 'PRICAT',
-      '15': 'QUOTES',
-      '33': 'REMADV',
-      '35': 'REQOTE',
-      '37': 'PARTIN',
-      '11': 'UTILMD',
-      '25': 'UTILTS',
-      '91': 'CONTRL',
-      '92': 'APERAK',
-      '44': 'UTILMDG',
-      '55': 'UTILMDS',
-    };
-
-    const key = pruefi.substring(0, 2);
-    return mapping[key] || '';
   }
 
   // split before [<condition>] and remove empty strings

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { AhbDiffLine, AhbDiffSide } from '../../../../core/api';
 import { IconLinkComponent } from '../../../../shared/components/icon-link/icon-link.component';
 import { environment } from '../../../../environments/environment';
+import { getFormatFromPruefi } from '../../../../shared/utils/pruefi-format.utils';
 
 @Component({
   selector: 'app-comparison-table',
@@ -116,7 +117,7 @@ export class ComparisonTableComponent {
       return null;
     }
     const encodedExpression = encodeURIComponent(expression);
-    return `${environment.bedingungsbaumBaseUrl}/tree/?format=${this.getFormat(this.pruefi)}&format_version=${formatVersion}&expression=${encodedExpression}`;
+    return `${environment.bedingungsbaumBaseUrl}/tree/?format=${getFormatFromPruefi(this.pruefi)}&format_version=${formatVersion}&expression=${encodedExpression}`;
   }
 
   generateEbdDeepLink(qualifier: string | null | undefined, formatVersion: string): string | null {
@@ -130,33 +131,5 @@ export class ComparisonTableComponent {
     }
     const ebdKey = match.groups['ebd_key']!;
     return `${environment.ebdBaseUrl}/ebd/?formatversion=${formatVersion}&ebd=${ebdKey}`;
-  }
-
-  private getFormat(pruefi: string): string {
-    const mapping: { [key: string]: string } = {
-      '99': 'APERAK',
-      '29': 'COMDIS',
-      '21': 'IFTSTA',
-      '23': 'INSRPT',
-      '31': 'INVOIC',
-      '13': 'MSCONS',
-      '39': 'ORDCHG',
-      '17': 'ORDERS',
-      '19': 'ORDRSP',
-      '27': 'PRICAT',
-      '15': 'QUOTES',
-      '33': 'REMADV',
-      '35': 'REQOTE',
-      '37': 'PARTIN',
-      '11': 'UTILMD',
-      '25': 'UTILTS',
-      '91': 'CONTRL',
-      '92': 'APERAK',
-      '44': 'UTILMDG',
-      '55': 'UTILMDS',
-    };
-
-    const key = pruefi.substring(0, 2);
-    return mapping[key] || '';
   }
 }

--- a/src/app/shared/utils/pruefi-format.utils.spec.ts
+++ b/src/app/shared/utils/pruefi-format.utils.spec.ts
@@ -1,0 +1,58 @@
+import { getFormatFromPruefi, getAllFormats } from './pruefi-format.utils';
+
+describe('pruefi-format.utils', () => {
+  describe('getFormatFromPruefi', () => {
+    it('should return UTILMD for pruefi starting with 11', () => {
+      expect(getFormatFromPruefi('11001')).toBe('UTILMD');
+      expect(getFormatFromPruefi('11042')).toBe('UTILMD');
+    });
+
+    it('should return MSCONS for pruefi starting with 13', () => {
+      expect(getFormatFromPruefi('13001')).toBe('MSCONS');
+    });
+
+    it('should return PARTIN for pruefi starting with 37', () => {
+      expect(getFormatFromPruefi('37005')).toBe('PARTIN');
+    });
+
+    it('should return UTILMDS for pruefi starting with 55', () => {
+      expect(getFormatFromPruefi('55014')).toBe('UTILMDS');
+    });
+
+    it('should return APERAK for pruefi starting with 99 or 92', () => {
+      expect(getFormatFromPruefi('99001')).toBe('APERAK');
+      expect(getFormatFromPruefi('92001')).toBe('APERAK');
+    });
+
+    it('should return empty string for unknown prefix', () => {
+      expect(getFormatFromPruefi('00001')).toBe('');
+      expect(getFormatFromPruefi('12345')).toBe('');
+    });
+
+    it('should handle short strings gracefully', () => {
+      expect(getFormatFromPruefi('1')).toBe('');
+      expect(getFormatFromPruefi('')).toBe('');
+    });
+  });
+
+  describe('getAllFormats', () => {
+    it('should return all unique formats sorted alphabetically', () => {
+      const formats = getAllFormats();
+
+      expect(formats).toContain('UTILMD');
+      expect(formats).toContain('MSCONS');
+      expect(formats).toContain('PARTIN');
+      expect(formats).toContain('APERAK');
+
+      // Check alphabetical order
+      const sortedFormats = [...formats].sort();
+      expect(formats).toEqual(sortedFormats);
+    });
+
+    it('should not contain duplicates', () => {
+      const formats = getAllFormats();
+      const uniqueFormats = new Set(formats);
+      expect(formats.length).toBe(uniqueFormats.size);
+    });
+  });
+});

--- a/src/app/shared/utils/pruefi-format.utils.ts
+++ b/src/app/shared/utils/pruefi-format.utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Mapping from Prüfidentifikator prefix (first 2 digits) to EDIFACT format.
+ * Each Prüfidentifikator starts with a 2-digit prefix that identifies the format.
+ */
+const PRUEFI_PREFIX_TO_FORMAT: Record<string, string> = {
+  '11': 'UTILMD',
+  '13': 'MSCONS',
+  '15': 'QUOTES',
+  '17': 'ORDERS',
+  '19': 'ORDRSP',
+  '21': 'IFTSTA',
+  '23': 'INSRPT',
+  '25': 'UTILTS',
+  '27': 'PRICAT',
+  '29': 'COMDIS',
+  '31': 'INVOIC',
+  '33': 'REMADV',
+  '35': 'REQOTE',
+  '37': 'PARTIN',
+  '39': 'ORDCHG',
+  '44': 'UTILMDG',
+  '55': 'UTILMDS',
+  '91': 'CONTRL',
+  '92': 'APERAK',
+  '99': 'APERAK',
+};
+
+/**
+ * Get the EDIFACT format for a given Prüfidentifikator.
+ * @param pruefi - The 5-digit Prüfidentifikator (e.g., '11001', '55014')
+ * @returns The EDIFACT format name (e.g., 'UTILMD', 'UTILMDS') or empty string if unknown
+ */
+export function getFormatFromPruefi(pruefi: string): string {
+  const prefix = pruefi.substring(0, 2);
+  return PRUEFI_PREFIX_TO_FORMAT[prefix] || '';
+}
+
+/**
+ * Get all known EDIFACT formats in alphabetical order.
+ * Useful for grouping and sorting operations.
+ */
+export function getAllFormats(): string[] {
+  const formats = new Set(Object.values(PRUEFI_PREFIX_TO_FORMAT));
+  return Array.from(formats).sort();
+}


### PR DESCRIPTION
Extract the getFormatFromPruefi() function from ahb-table.component.ts
and comparison-table.component.ts into a shared utility at
src/app/shared/utils/pruefi-format.utils.ts.

This eliminates code duplication and provides a single source of truth
for the mapping between Prüfidentifikator prefixes and EDIFACT formats.

The utility also exports getAllFormats() which returns all known formats
sorted alphabetically, useful for grouping and display purposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
