### PR TITLE
feat(comparison-condition): Adds on-demand conditions column visibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@auth0/auth0-angular": "^2.2.3",
         "@mdi/font": "^7.4.47",
         "cors": "^2.8.5",
+        "diff": "^8.0.2",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
         "prettier": "^3.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@angular-eslint/template-parser": "^19.5.0",
         "@angular/cli": "^19.2.13",
         "@angular/compiler-cli": "^19.2.13",
+        "@types/diff": "^7.0.2",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.14",
         "@typescript-eslint/eslint-plugin": "^8.32.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6432,6 +6432,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -9491,6 +9498,15 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@auth0/auth0-angular": "^2.2.3",
     "@mdi/font": "^7.4.47",
     "cors": "^2.8.5",
+    "diff": "^8.0.2",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "prettier": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@angular-eslint/template-parser": "^19.5.0",
     "@angular/cli": "^19.2.13",
     "@angular/compiler-cli": "^19.2.13",
+    "@types/diff": "^7.0.2",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.14",
     "@typescript-eslint/eslint-plugin": "^8.32.1",

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -3,11 +3,15 @@
     <table class="table-auto w-full text-sm text-gray-800">
       <thead>
         <tr>
-          <th colspan="6" class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
+          <th
+            [attr.colspan]="showConditionsColumn() ? 7 : 6"
+            class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
             Alte Version ({{ formatVersionOld }})
           </th>
           <th class="w-6 bg-hf-pastell-rose"></th>
-          <th colspan="6" class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
+          <th
+            [attr.colspan]="showConditionsColumn() ? 7 : 6"
+            class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
             Neue Version ({{ formatVersionNew }})
           </th>
         </tr>
@@ -19,6 +23,9 @@
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Qualifier</th>
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Name</th>
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Status</th>
+          @if (showConditionsColumn()) {
+            <th class="px-3 py-2 text-left bg-hf-pastell-rose">Bedingung</th>
+          }
           <th class="w-6 bg-hf-pastell-rose"></th>
           <!-- New version columns -->
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Segmentgruppe</th>
@@ -27,6 +34,9 @@
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Qualifier</th>
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Name</th>
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Status</th>
+          @if (showConditionsColumn()) {
+            <th class="px-3 py-2 text-left bg-hf-pastell-rose">Bedingung</th>
+          }
         </tr>
       </thead>
       <tbody>
@@ -76,6 +86,11 @@
                 {{ getAhbStatus(line, 'old') || '-' }}
               }
             </td>
+            @if (showConditionsColumn()) {
+              <td class="px-3 py-2" [class]="getChangedColumnClass(line, 'bedingung')">
+                {{ getBedingung(line, 'old') || '-' }}
+              </td>
+            }
 
             <td class="bg-hf-pastell-rose"></td>
 
@@ -123,6 +138,11 @@
                 {{ getAhbStatus(line, 'new') || '-' }}
               }
             </td>
+            @if (showConditionsColumn()) {
+              <td class="px-3 py-2" [class]="getChangedColumnClass(line, 'bedingung')">
+                {{ getBedingung(line, 'new') || '-' }}
+              </td>
+            }
           </tr>
         }
       </tbody>

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -85,8 +85,8 @@
               }
             </td>
             @if (showConditionsColumn()) {
-              <td class="px-3 py-2" [class]="getChangedColumnClass(line, 'bedingung')">
-                {{ getBedingung(line, 'old') || '-' }}
+              <td class="px-3 py-2">
+                <span [innerHTML]="getHighlightedBedingung(line, 'old')"></span>
               </td>
             }
 
@@ -135,8 +135,8 @@
               }
             </td>
             @if (showConditionsColumn()) {
-              <td class="px-3 py-2" [class]="getChangedColumnClass(line, 'bedingung')">
-                {{ getBedingung(line, 'new') || '-' }}
+              <td class="px-3 py-2">
+                <span [innerHTML]="getHighlightedBedingung(line, 'new')"></span>
               </td>
             }
           </tr>

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -71,9 +71,7 @@
             <td class="px-3 py-2" [class]="getChangedColumnClass(line, 'line_name')">
               {{ getName(line, 'old') || '-' }}
             </td>
-            <td
-              class="px-3 py-2"
-              [class]="getChangedColumnClass(line, ['line_ahb_status', 'bedingung'])">
+            <td class="px-3 py-2" [class]="getChangedColumnClass(line, 'line_ahb_status')">
               @if (
                 generateBedingungsbaumDeepLink(getAhbStatus(line, 'old'), formatVersionOld);
                 as treeLink
@@ -123,9 +121,7 @@
             <td class="px-3 py-2" [class]="getChangedColumnClass(line, 'line_name')">
               {{ getName(line, 'new') || '-' }}
             </td>
-            <td
-              class="px-3 py-2"
-              [class]="getChangedColumnClass(line, ['line_ahb_status', 'bedingung'])">
+            <td class="px-3 py-2" [class]="getChangedColumnClass(line, 'line_ahb_status')">
               @if (
                 generateBedingungsbaumDeepLink(getAhbStatus(line, 'new'), formatVersionNew);
                 as treeLink

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -4,13 +4,13 @@
       <thead>
         <tr>
           <th
-            [attr.colspan]="showConditionsColumn() ? 7 : 6"
+            [attr.colspan]="showConditionsColumn ? 7 : 6"
             class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
             Alte Version ({{ formatVersionOld }})
           </th>
           <th class="w-6 bg-hf-pastell-rose"></th>
           <th
-            [attr.colspan]="showConditionsColumn() ? 7 : 6"
+            [attr.colspan]="showConditionsColumn ? 7 : 6"
             class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
             Neue Version ({{ formatVersionNew }})
           </th>
@@ -23,7 +23,7 @@
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Qualifier</th>
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Name</th>
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Status</th>
-          @if (showConditionsColumn()) {
+          @if (showConditionsColumn) {
             <th class="px-3 py-2 text-left bg-hf-pastell-rose">Bedingung</th>
           }
           <th class="w-6 bg-hf-pastell-rose"></th>
@@ -34,7 +34,7 @@
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Qualifier</th>
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Name</th>
           <th class="px-3 py-2 text-left bg-hf-pastell-rose">Status</th>
-          @if (showConditionsColumn()) {
+          @if (showConditionsColumn) {
             <th class="px-3 py-2 text-left bg-hf-pastell-rose">Bedingung</th>
           }
         </tr>
@@ -84,7 +84,7 @@
                 {{ getAhbStatus(line, 'old') || '-' }}
               }
             </td>
-            @if (showConditionsColumn()) {
+            @if (showConditionsColumn) {
               <td class="px-3 py-2">
                 <span [innerHTML]="getHighlightedBedingung(line, 'old')"></span>
               </td>
@@ -134,7 +134,7 @@
                 {{ getAhbStatus(line, 'new') || '-' }}
               }
             </td>
-            @if (showConditionsColumn()) {
+            @if (showConditionsColumn) {
               <td class="px-3 py-2">
                 <span [innerHTML]="getHighlightedBedingung(line, 'new')"></span>
               </td>

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -134,7 +134,8 @@ export class ComparisonTableComponent {
   }
 
   /**
-   * Compare two bedingung strings word-by-word and return HTML with differences wrapped in <strong> tags
+   * Compare two bedingung strings and return HTML with unique words wrapped in <strong> tags.
+   * Uses set-based comparison to highlight words that exist in one version but not the other.
    */
   getHighlightedBedingung(line: AhbDiffLine, side: 'old' | 'new'): string {
     const oldText = line.old?.bedingung ?? '';
@@ -146,15 +147,23 @@ export class ComparisonTableComponent {
       return this.escapeHtml(currentText) || '-';
     }
 
-    // Split into words (preserving whitespace)
-    const currentWords = currentText.split(/(\s+)/);
-    const otherWords = otherText.split(/(\s+)/);
+    // Create a set of words from the other text for efficient lookup
+    const otherWordsSet = new Set(
+      otherText
+        .split(/\s+/)
+        .filter(w => w.trim())
+        .map(w => w.toLowerCase())
+    );
 
-    // Build highlighted output
-    return currentWords
-      .map((word, i) => {
-        const escaped = this.escapeHtml(word);
-        if (otherWords[i] !== word && word.trim()) {
+    // Split current text into words while preserving whitespace for reconstruction
+    const currentTokens = currentText.split(/(\s+)/);
+
+    // Build highlighted output - bold words that don't exist in the other text
+    return currentTokens
+      .map(token => {
+        const escaped = this.escapeHtml(token);
+        // Only highlight non-whitespace tokens that aren't in the other text
+        if (token.trim() && !otherWordsSet.has(token.toLowerCase())) {
           return `<strong>${escaped}</strong>`;
         }
         return escaped;

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AhbDiffLine, AhbDiffSide } from '../../../../core/api';
 import { IconLinkComponent } from '../../../../shared/components/icon-link/icon-link.component';
@@ -18,7 +18,7 @@ export class ComparisonTableComponent {
   @Input() pruefi = '';
 
   /** Whether to show the conditions/hints/formats column */
-  showConditionsColumn = input(false);
+  @Input() showConditionsColumn = false;
 
   getRowClass(line: AhbDiffLine): string {
     switch (line.diff_status) {

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { diffWords } from 'diff';
 import { AhbDiffLine, AhbDiffSide } from '../../../../core/api';
 import { IconLinkComponent } from '../../../../shared/components/icon-link/icon-link.component';
 import { environment } from '../../../../environments/environment';
@@ -134,39 +135,40 @@ export class ComparisonTableComponent {
   }
 
   /**
-   * Compare two bedingung strings and return HTML with unique words wrapped in <strong> tags.
-   * Uses set-based comparison to highlight words that exist in one version but not the other.
+   * Compare two bedingung strings using proper diff algorithm.
+   * Highlights added words (in new) or removed words (in old) with <strong> tags.
    */
   getHighlightedBedingung(line: AhbDiffLine, side: 'old' | 'new'): string {
     const oldText = line.old?.bedingung ?? '';
     const newText = line.new?.bedingung ?? '';
     const currentText = side === 'old' ? oldText : newText;
-    const otherText = side === 'old' ? newText : oldText;
 
     if (!this.isColumnChanged(line, 'bedingung') || !currentText) {
       return this.escapeHtml(currentText) || '-';
     }
 
-    // Create a set of words from the other text for efficient lookup
-    const otherWordsSet = new Set(
-      otherText
-        .split(/\s+/)
-        .filter(w => w.trim())
-        .map(w => w.toLowerCase())
-    );
+    // diffWords returns an array of change objects with added/removed flags
+    const changes = diffWords(oldText, newText);
 
-    // Split current text into words while preserving whitespace for reconstruction
-    const currentTokens = currentText.split(/(\s+)/);
+    // Build the highlighted output for the requested side
+    return changes
+      .map(change => {
+        const escaped = this.escapeHtml(change.value);
 
-    // Build highlighted output - bold words that don't exist in the other text
-    return currentTokens
-      .map(token => {
-        const escaped = this.escapeHtml(token);
-        // Only highlight non-whitespace tokens that aren't in the other text
-        if (token.trim() && !otherWordsSet.has(token.toLowerCase())) {
+        if (side === 'old' && change.removed) {
+          // Word was removed (exists only in old)
           return `<strong>${escaped}</strong>`;
         }
-        return escaped;
+        if (side === 'new' && change.added) {
+          // Word was added (exists only in new)
+          return `<strong>${escaped}</strong>`;
+        }
+        if (!change.added && !change.removed) {
+          // Unchanged text - show on both sides
+          return escaped;
+        }
+        // Skip: added words when showing old side, removed words when showing new side
+        return '';
       })
       .join('');
   }

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -137,6 +137,41 @@ export class ComparisonTableComponent {
     return this.getSide(line, side)?.bedingung ?? '';
   }
 
+  /**
+   * Compare two bedingung strings word-by-word and return HTML with differences wrapped in <strong> tags
+   */
+  getHighlightedBedingung(line: AhbDiffLine, side: 'old' | 'new'): string {
+    const oldText = line.old?.bedingung ?? '';
+    const newText = line.new?.bedingung ?? '';
+    const currentText = side === 'old' ? oldText : newText;
+    const otherText = side === 'old' ? newText : oldText;
+
+    if (!this.isColumnChanged(line, 'bedingung') || !currentText) {
+      return this.escapeHtml(currentText) || '-';
+    }
+
+    // Split into words (preserving whitespace)
+    const currentWords = currentText.split(/(\s+)/);
+    const otherWords = otherText.split(/(\s+)/);
+
+    // Build highlighted output
+    return currentWords
+      .map((word, i) => {
+        const escaped = this.escapeHtml(word);
+        if (otherWords[i] !== word && word.trim()) {
+          return `<strong>${escaped}</strong>`;
+        }
+        return escaped;
+      })
+      .join('');
+  }
+
+  private escapeHtml(text: string): string {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
   generateBedingungsbaumDeepLink(expression: string, formatVersion: string): string | null {
     if (!expression || !expression.includes('[')) {
       return null;

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AhbDiffLine, AhbDiffSide } from '../../../../core/api';
 import { IconLinkComponent } from '../../../../shared/components/icon-link/icon-link.component';
@@ -16,6 +16,9 @@ export class ComparisonTableComponent {
   @Input() formatVersionOld = '';
   @Input() formatVersionNew = '';
   @Input() pruefi = '';
+
+  /** Whether to show the conditions/hints/formats column */
+  showConditionsColumn = input(false);
 
   getRowClass(line: AhbDiffLine): string {
     switch (line.diff_status) {
@@ -128,6 +131,10 @@ export class ComparisonTableComponent {
 
   getAhbStatus(line: AhbDiffLine, side: 'old' | 'new'): string {
     return this.getSide(line, side)?.line_ahb_status ?? '';
+  }
+
+  getBedingung(line: AhbDiffLine, side: 'old' | 'new'): string {
+    return this.getSide(line, side)?.bedingung ?? '';
   }
 
   generateBedingungsbaumDeepLink(expression: string, formatVersion: string): string | null {

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -133,10 +133,6 @@ export class ComparisonTableComponent {
     return this.getSide(line, side)?.line_ahb_status ?? '';
   }
 
-  getBedingung(line: AhbDiffLine, side: 'old' | 'new'): string {
-    return this.getSide(line, side)?.bedingung ?? '';
-  }
-
   /**
    * Compare two bedingung strings word-by-word and return HTML with differences wrapped in <strong> tags
    */

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -174,9 +174,12 @@ export class ComparisonTableComponent {
   }
 
   private escapeHtml(text: string): string {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
   }
 
   generateBedingungsbaumDeepLink(expression: string, formatVersion: string): string | null {

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.html
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.html
@@ -52,7 +52,7 @@
 
         <!-- Statistics / Filter Toggles -->
         @if (stats(); as stats) {
-          <div class="flex flex-wrap gap-2 text-sm">
+          <div class="flex flex-wrap items-center gap-2 text-sm">
             @for (toggle of filterToggles; track toggle.key) {
               <button
                 type="button"
@@ -66,6 +66,25 @@
                 {{ toggle.symbol }}{{ stats[toggle.key] }}
               </button>
             }
+
+            <!-- Divider -->
+            <span class="mx-1 h-6 w-px bg-gray-300"></span>
+
+            <!-- Column visibility toggle -->
+            <button
+              type="button"
+              (click)="showConditionsColumn.set(!showConditionsColumn())"
+              class="px-3 py-1.5 rounded font-medium cursor-pointer transition-all focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2 border-2"
+              [class]="
+                showConditionsColumn()
+                  ? 'bg-hf-dunkel-rose text-white border-hf-dunkel-rose focus:ring-hf-dunkel-rose hover:ring-hf-dunkel-rose'
+                  : 'bg-white text-gray-700 border-gray-300 focus:ring-gray-400 hover:ring-gray-400'
+              "
+              [attr.aria-pressed]="showConditionsColumn() ? 'true' : 'false'"
+              aria-label="Bedingungen-Spalte ein-/ausblenden"
+              title="Bedingungen-Spalte ein-/ausblenden">
+              Bedingungen
+            </button>
           </div>
         }
       </div>
@@ -94,7 +113,8 @@
           [lines]="filteredLines()"
           [formatVersionOld]="formatVersionOld()"
           [formatVersionNew]="formatVersionNew()"
-          [pruefi]="pruefi()" />
+          [pruefi]="pruefi()"
+          [showConditionsColumn]="showConditionsColumn()" />
       } @else if (stats()) {
         <!-- Has data but all filtered out -->
         <div class="text-center py-12 text-gray-500">

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.ts
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.ts
@@ -58,6 +58,9 @@ export class ComparisonPageComponent implements OnInit, OnDestroy {
   showDeleted = signal(true);
   showModified = signal(true);
 
+  /** Column visibility: conditions/hints/formats column (hidden by default) */
+  showConditionsColumn = signal(false);
+
   /** Filter toggle button configurations */
   readonly filterToggles = [
     {


### PR DESCRIPTION
Adds the ability to toggle the visibility of the conditions/hints/formats column in the comparison table.

This enhances user experience by allowing users to focus on relevant information.

The implementation includes:
- A toggle button in the comparison page to control the column's visibility.
- Logic in the comparison table component to dynamically render the column based on the toggle state.
- Word-by-word highlighting of differences within the 'bedingung' field.