### PR TITLE
feat(search): add wildcard info popover to global search

### DIFF
--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { diffWords } from 'diff';
+import { diffWords, Change } from 'diff';
 import { AhbDiffLine, AhbDiffSide } from '../../../../core/api';
 import { IconLinkComponent } from '../../../../shared/components/icon-link/icon-link.component';
 import { environment } from '../../../../environments/environment';
@@ -157,7 +157,7 @@ export class ComparisonTableComponent {
 
     // Build the highlighted output for the requested side
     return changes
-      .map(change => {
+      .map((change: Change) => {
         const escaped = this.escapeHtml(change.value);
 
         if (side === 'old' && change.removed) {

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -35,6 +35,8 @@
           <strong>Beispiel:</strong>
           <ul>
             <li><code>Konfig*ID</code> → findet "Konfigurations-ID" und "Konfig-ID"</li>
+            <li><code>Konfig*</code> → findet "Konfigurations-ID" und "Konfigurationsprodukt"</li>
+            <li><code>*produkt</code> → findet "Konfigurationsproduk" und "Messprodukt" aber nicht "Produkt-/Leistungsbeschreibung"</li>
           </ul>
         </div>
         <p class="wildcard-info-note">

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -37,9 +37,8 @@
           </ul>
         </div>
         <p class="wildcard-info-note">
-          <strong>Hinweis:</strong> <code>Konfig</code> und <code>*Konfig*</code> liefern
-          dasselbe Ergebnis, da ohne <code>*</code> automatisch eine "enthält"-Suche
-          durchgeführt wird.
+          <strong>Hinweis:</strong> <code>Konfig</code> und <code>*Konfig*</code> liefern dasselbe
+          Ergebnis, da ohne <code>*</code> automatisch eine "enthält"-Suche durchgeführt wird.
         </p>
       </div>
     </ng-template>

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -4,19 +4,20 @@
     <mat-form-field appearance="fill" class="search-field">
       <mat-label>Globale Suche</mat-label>
       <input matInput formControlName="q" placeholder="Durchsuche alle AHBs…" />
-      <button
-        mat-icon-button
-        matSuffix
-        type="button"
-        class="wildcard-info-button"
-        cdkOverlayOrigin
-        #wildcardInfoTrigger="cdkOverlayOrigin"
-        (click)="wildcardInfoOpen = !wildcardInfoOpen"
-        [attr.aria-expanded]="wildcardInfoOpen"
-        aria-label="Informationen zur Platzhalter-Suche">
-        <mat-icon fontSet="mdi" fontIcon="mdi-information-outline"></mat-icon>
-      </button>
-      <mat-icon matSuffix fontSet="mdi" fontIcon="mdi-magnify"></mat-icon>
+      <span matSuffix class="search-suffix-container">
+        <button
+          mat-icon-button
+          type="button"
+          class="wildcard-info-button"
+          cdkOverlayOrigin
+          #wildcardInfoTrigger="cdkOverlayOrigin"
+          (click)="wildcardInfoOpen = !wildcardInfoOpen"
+          [attr.aria-expanded]="wildcardInfoOpen"
+          aria-label="Informationen zur Platzhalter-Suche">
+          <mat-icon fontSet="mdi" fontIcon="mdi-information-outline"></mat-icon>
+        </button>
+        <mat-icon fontSet="mdi" fontIcon="mdi-magnify"></mat-icon>
+      </span>
     </mat-form-field>
 
     <ng-template

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -37,7 +37,7 @@
             <li><code>Konfig*ID</code> → findet "Konfigurations-ID" und "Konfig-ID"</li>
             <li><code>Konfig*</code> → findet "Konfigurations-ID" und "Konfigurationsprodukt"</li>
             <li>
-              <code>*produkt</code> → findet "Konfigurationsproduk" und "Messprodukt" aber nicht
+              <code>*produkt</code> → findet "Konfigurationsprodukt" und "Messprodukt" aber nicht
               "Produkt-/Leistungsbeschreibung"
             </li>
           </ul>

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -36,7 +36,10 @@
           <ul>
             <li><code>Konfig*ID</code> → findet "Konfigurations-ID" und "Konfig-ID"</li>
             <li><code>Konfig*</code> → findet "Konfigurations-ID" und "Konfigurationsprodukt"</li>
-            <li><code>*produkt</code> → findet "Konfigurationsproduk" und "Messprodukt" aber nicht "Produkt-/Leistungsbeschreibung"</li>
+            <li>
+              <code>*produkt</code> → findet "Konfigurationsproduk" und "Messprodukt" aber nicht
+              "Produkt-/Leistungsbeschreibung"
+            </li>
           </ul>
         </div>
         <p class="wildcard-info-note">

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -30,7 +30,7 @@
       [cdkConnectedOverlayPositions]="wildcardInfoPositions">
       <div class="wildcard-info-popover">
         <div class="wildcard-info-header">Platzhalter-Suche</div>
-        <p>Verwenden Sie <code>*</code> als Platzhalter für beliebige Zeichen.</p>
+        <p>Verwende <code>*</code> als Platzhalter für beliebige Zeichen.</p>
         <div class="wildcard-info-examples">
           <strong>Beispiel:</strong>
           <ul>

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -4,8 +4,41 @@
     <mat-form-field appearance="fill" class="search-field">
       <mat-label>Globale Suche</mat-label>
       <input matInput formControlName="q" placeholder="Durchsuche alle AHBs…" />
+      <button
+        mat-icon-button
+        matSuffix
+        type="button"
+        class="wildcard-info-button"
+        cdkOverlayOrigin
+        #wildcardInfoTrigger="cdkOverlayOrigin"
+        (click)="wildcardInfoOpen = !wildcardInfoOpen"
+        [attr.aria-expanded]="wildcardInfoOpen"
+        aria-label="Informationen zur Platzhalter-Suche">
+        <mat-icon fontSet="mdi" fontIcon="mdi-information-outline"></mat-icon>
+      </button>
       <mat-icon matSuffix fontSet="mdi" fontIcon="mdi-magnify"></mat-icon>
     </mat-form-field>
+
+    <ng-template
+      cdkConnectedOverlay
+      [cdkConnectedOverlayOrigin]="wildcardInfoTrigger"
+      [cdkConnectedOverlayOpen]="wildcardInfoOpen"
+      [cdkConnectedOverlayHasBackdrop]="true"
+      [cdkConnectedOverlayBackdropClass]="'cdk-overlay-transparent-backdrop'"
+      (backdropClick)="wildcardInfoOpen = false"
+      [cdkConnectedOverlayPositions]="wildcardInfoPositions">
+      <div class="wildcard-info-popover">
+        <div class="wildcard-info-header">Platzhalter-Suche</div>
+        <p>Verwenden Sie <code>*</code> als Platzhalter für beliebige Zeichen.</p>
+        <div class="wildcard-info-examples">
+          <strong>Beispiele:</strong>
+          <ul>
+            <li><code>Konfig*ID</code> → findet "Konfigurations-ID" und "Konfig-ID"</li>
+            <li><code>Konfig*</code> → findet "Konfiguration", "Konfig-ID", usw.</li>
+          </ul>
+        </div>
+      </div>
+    </ng-template>
   </div>
 
   <!-- Individual Filters -->

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -31,12 +31,16 @@
         <div class="wildcard-info-header">Platzhalter-Suche</div>
         <p>Verwenden Sie <code>*</code> als Platzhalter für beliebige Zeichen.</p>
         <div class="wildcard-info-examples">
-          <strong>Beispiele:</strong>
+          <strong>Beispiel:</strong>
           <ul>
             <li><code>Konfig*ID</code> → findet "Konfigurations-ID" und "Konfig-ID"</li>
-            <li><code>Konfig*</code> → findet "Konfiguration", "Konfig-ID", usw.</li>
           </ul>
         </div>
+        <p class="wildcard-info-note">
+          <strong>Hinweis:</strong> <code>Konfig</code> und <code>*Konfig*</code> liefern
+          dasselbe Ergebnis, da ohne <code>*</code> automatisch eine "enthält"-Suche
+          durchgeführt wird.
+        </p>
       </div>
     </ng-template>
   </div>

--- a/src/app/features/search/components/search-filters/search-filters.component.html
+++ b/src/app/features/search/components/search-filters/search-filters.component.html
@@ -28,8 +28,8 @@
       [cdkConnectedOverlayBackdropClass]="'cdk-overlay-transparent-backdrop'"
       (backdropClick)="wildcardInfoOpen = false"
       [cdkConnectedOverlayPositions]="wildcardInfoPositions">
-      <div class="wildcard-info-popover">
-        <div class="wildcard-info-header">Platzhalter-Suche</div>
+      <div class="wildcard-info-popover" role="dialog" aria-labelledby="wildcard-info-title">
+        <div id="wildcard-info-title" class="wildcard-info-header">Platzhalter-Suche</div>
         <p>Verwende <code>*</code> als Platzhalter für beliebige Zeichen.</p>
         <div class="wildcard-info-examples">
           <strong>Beispiel:</strong>

--- a/src/app/features/search/components/search-filters/search-filters.component.scss
+++ b/src/app/features/search/components/search-filters/search-filters.component.scss
@@ -65,6 +65,14 @@
       }
     }
   }
+
+  .wildcard-info-note {
+    margin: 12px 0 0;
+    padding-top: 12px;
+    border-top: 1px solid #e0e0e0;
+    font-size: 13px;
+    color: #666;
+  }
 }
 
 .filter-grid {

--- a/src/app/features/search/components/search-filters/search-filters.component.scss
+++ b/src/app/features/search/components/search-filters/search-filters.component.scss
@@ -9,6 +9,62 @@
     width: 100%;
     max-width: 400px;
   }
+
+  .wildcard-info-button {
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
+
+    &:hover,
+    &:focus {
+      opacity: 1;
+    }
+  }
+}
+
+.wildcard-info-popover {
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow:
+    0 4px 6px -1px rgb(0 0 0 / 10%),
+    0 2px 4px -2px rgb(0 0 0 / 10%);
+  max-width: 320px;
+  font-size: 14px;
+  line-height: 1.5;
+
+  .wildcard-info-header {
+    font-weight: 600;
+    font-size: 15px;
+    margin-bottom: 8px;
+    color: var(--mat-sys-primary, #1976d2);
+  }
+
+  p {
+    margin: 0 0 12px;
+  }
+
+  code {
+    background: #f5f5f5;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 13px;
+  }
+
+  .wildcard-info-examples {
+    ul {
+      margin: 8px 0 0;
+      padding-left: 20px;
+
+      li {
+        margin-bottom: 4px;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
 }
 
 .filter-grid {

--- a/src/app/features/search/components/search-filters/search-filters.component.scss
+++ b/src/app/features/search/components/search-filters/search-filters.component.scss
@@ -10,6 +10,12 @@
     max-width: 400px;
   }
 
+  .search-suffix-container {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
   .wildcard-info-button {
     opacity: 0.6;
     transition: opacity 0.2s ease;

--- a/src/app/features/search/components/search-filters/search-filters.component.spec.ts
+++ b/src/app/features/search/components/search-filters/search-filters.component.spec.ts
@@ -239,6 +239,18 @@ describe('SearchFiltersComponent', () => {
 
       expect(component.wildcardInfoOpen).toBe(false);
     });
+
+    it('should toggle wildcardInfoOpen when clicking info button', () => {
+      expect(component.wildcardInfoOpen).toBe(false);
+
+      // Toggle open
+      component.wildcardInfoOpen = !component.wildcardInfoOpen;
+      expect(component.wildcardInfoOpen).toBe(true);
+
+      // Toggle closed
+      component.wildcardInfoOpen = !component.wildcardInfoOpen;
+      expect(component.wildcardInfoOpen).toBe(false);
+    });
   });
 
   describe('format loading', () => {

--- a/src/app/features/search/components/search-filters/search-filters.component.spec.ts
+++ b/src/app/features/search/components/search-filters/search-filters.component.spec.ts
@@ -214,6 +214,33 @@ describe('SearchFiltersComponent', () => {
     });
   });
 
+  describe('wildcard info popover', () => {
+    it('should initialize wildcardInfoOpen as false', () => {
+      expect(component.wildcardInfoOpen).toBe(false);
+    });
+
+    it('should have wildcard info positions defined', () => {
+      expect(component.wildcardInfoPositions).toBeDefined();
+      expect(component.wildcardInfoPositions.length).toBeGreaterThan(0);
+    });
+
+    it('should close popover when Escape key is pressed', () => {
+      component.wildcardInfoOpen = true;
+
+      component.onEscapeKey();
+
+      expect(component.wildcardInfoOpen).toBe(false);
+    });
+
+    it('should not change state when Escape is pressed and popover is already closed', () => {
+      component.wildcardInfoOpen = false;
+
+      component.onEscapeKey();
+
+      expect(component.wildcardInfoOpen).toBe(false);
+    });
+  });
+
   describe('format loading', () => {
     it('should handle format version loading error gracefully', () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();

--- a/src/app/features/search/components/search-filters/search-filters.component.ts
+++ b/src/app/features/search/components/search-filters/search-filters.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, OnDestroy, Output, EventEmitter, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, FormControl } from '@angular/forms';
 import { OverlayModule, ConnectedPosition } from '@angular/cdk/overlay';
@@ -269,5 +269,12 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
       }
       return typeof value === 'string' && value.trim();
     }).length;
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscapeKey(): void {
+    if (this.wildcardInfoOpen) {
+      this.wildcardInfoOpen = false;
+    }
   }
 }

--- a/src/app/features/search/components/search-filters/search-filters.component.ts
+++ b/src/app/features/search/components/search-filters/search-filters.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, FormControl } from '@angular/forms';
+import { OverlayModule, ConnectedPosition } from '@angular/cdk/overlay';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -21,6 +22,7 @@ import { RichtungCacheService } from '../../services/richtung-cache.service';
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    OverlayModule,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
@@ -36,6 +38,24 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
   searchForm: FormGroup;
+
+  wildcardInfoOpen = false;
+  wildcardInfoPositions: ConnectedPosition[] = [
+    {
+      originX: 'end',
+      originY: 'bottom',
+      overlayX: 'end',
+      overlayY: 'top',
+      offsetY: 8,
+    },
+    {
+      originX: 'start',
+      originY: 'bottom',
+      overlayX: 'start',
+      overlayY: 'top',
+      offsetY: 8,
+    },
+  ];
 
   filterFields: Array<{
     key: string;


### PR DESCRIPTION
Add an info icon button next to the search input that opens a popover explaining the wildcard (*) search feature with German examples.
<img width="507" height="453" alt="{9A905E29-35F8-474F-A119-6AAEF9CA156D}" src="https://github.com/user-attachments/assets/0fdbdb31-169d-492e-a9b3-8ac980bd885d" />


Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)