### PR TITLE
infra(pulumi): add configurable App Service Plan SKU settings

### DIFF
--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -11,6 +11,6 @@ jobs:
       - name: PR Conventional Commit Validation
         uses: ytanikin/PRConventionalCommits@1.3.0
         with:
-          task_types: '["feat","fix","refactor","docs","perf","style","test","chore","ci","revert"]'
+          task_types: '["feat","fix","refactor","docs","perf","style","test","chore","ci","revert","build","wip","deps","security","infra"]'
           add_label: 'true'
-          custom_labels: '{"feat": "feature", "fix": "fix", "docs": "documentation", "test": "test", "ci": "CI/CD", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "wip": "WIP"}'
+          custom_labels: '{"feat": "feature", "fix": "fix", "docs": "documentation", "test": "test", "ci": "CI/CD", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "build": "build", "wip": "WIP", "deps": "dependencies", "security": "security", "infra": "infrastructure"}'

--- a/pulumi/Pulumi.prod.yaml
+++ b/pulumi/Pulumi.prod.yaml
@@ -1,8 +1,9 @@
 config:
   ahb-tabellen:appPath: app
+  ahb-tabellen:appServicePlanSkuName: "B1"
+  ahb-tabellen:appServicePlanSkuTier: "Basic"
   ahb-tabellen:bedingungsbaumBaseUrl: https://bedingungsbaum.hochfrequenz.de
   ahb-tabellen:containerPort: "80"
-  ahb-tabellen:cpu: "1"
   ahb-tabellen:db_7z_archive_password:
     secure: AAABAG9VAmOftI7npdJm+AxiHDF90IWlsDdCQxNGeJImf4j21yqJi+GDTxI71zYlQ38da4IAEuzc/fXW1p4=
   ahb-tabellen:ebdBaseUrl: https://ebd.hochfrequenz.de
@@ -11,7 +12,6 @@ config:
     secure: AAABAPxqz5l9dn9CRjuSdmBw1dz+WQpoqfXJ1pRz5SzsxAuKHMB8mOo+Ir3nCllS0u8VjraFpDnDqGq1SA5a6RbNeOl49eJ+
   ahb-tabellen:imageName: ghcr.io/hochfrequenz/ahb-tabellen
   ahb-tabellen:imageTag: v1.4.0
-  ahb-tabellen:memory: "2"
   ahb-tabellen:ohDearHealthCheckSecret:
     secure: AAABANrflh/RuuKGiZEPld6MZksWHZZsRfivLLSXEW7gMaC0k+omHcGtixSle5ok
   ahb-tabellen:websitesContainerStartTimeLimit: "300"

--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -1,8 +1,9 @@
 config:
   ahb-tabellen:appPath: app
+  ahb-tabellen:appServicePlanSkuName: "B2"
+  ahb-tabellen:appServicePlanSkuTier: "Basic"
   ahb-tabellen:bedingungsbaumBaseUrl: https://bedingungsbaum.stage.hochfrequenz.de
   ahb-tabellen:containerPort: "80"
-  ahb-tabellen:cpu: "1"
   ahb-tabellen:db_7z_archive_password:
     secure: AAABAKCZGXsqn3HVUmLUZYH/9jIIsqbvOJ50Vt4YCacdUABfog63VkVqStKJDYgXTve9Ny0hO1UaIUqKRPU=
   ahb-tabellen:ebdBaseUrl: https://ebd.stage.hochfrequenz.de
@@ -11,7 +12,6 @@ config:
     secure: AAABABkZ6JHu21N1Q6+hgJVXWzz7KkywfdZ84phM1XkWy6aTrm5zvSibf6PIxCcUJsJgeqDU3aexWUGI7ZH3nFOEIGtpoyKa
   ahb-tabellen:imageName: ghcr.io/hochfrequenz/ahb-tabellen
   ahb-tabellen:imageTag: v1.4.0-rc02
-  ahb-tabellen:memory: "2"
   ahb-tabellen:ohDearHealthCheckSecret:
     secure: AAABAFE/v/fLv99CnNg0sBE42GYr5nMYhNJoa1prN9EgomNzl9D0B3vgse7uW3w6
   ahb-tabellen:websitesContainerStartTimeLimit: "300"

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -38,8 +38,10 @@ assert oh_dear_health_check_secret, "ohDearHealthCheckSecret must be set"
 db_7z_archive_password = config.require_secret("db_7z_archive_password")
 assert db_7z_archive_password, "db_7z_archive_password must be set"
 
-cpu = config.get_int("cpu", 1)
-memory = config.get_int("memory", 2)
+# App Service Plan SKU configuration (see https://azure.microsoft.com/pricing/details/app-service/)
+# Common SKUs: B1/B2/B3 (Basic), S1/S2/S3 (Standard), P1v2/P2v2/P3v2 (PremiumV2)
+app_service_plan_sku_name = config.get("appServicePlanSkuName") or "B1"
+app_service_plan_sku_tier = config.get("appServicePlanSkuTier") or "Basic"
 
 # Get location from azure-native config
 azure_config = pulumi.Config("azure-native")
@@ -72,8 +74,8 @@ app_service_plan = azure_native.web.AppServicePlan(
     kind="Linux",
     reserved=True,  # Required for Linux App Service Plans, see https://stackoverflow.com/questions/66520937/pulumi-azure-native-provider-azure-webapp-the-parameter-linuxfxversion-has-an
     sku=azure_native.web.SkuDescriptionArgs(
-        name="B1",
-        tier="Basic",
+        name=app_service_plan_sku_name,
+        tier=app_service_plan_sku_tier,
     ),
 )
 


### PR DESCRIPTION
Introduce new configuration options for App Service Plan SKU name and tier in Pulumi setup. The default values are set to "B1" and "Basic" respectively, allowing for easier customization in deployment configurations. Removed hardcoded CPU and memory settings from the configuration files.
