### PR TITLE
fix: remove duplicate "." in error text

### DIFF
--- a/src/app/shared/components/fallback-page/fallback-page.component.html
+++ b/src/app/shared/components/fallback-page/fallback-page.component.html
@@ -16,7 +16,7 @@
         <a
           href="https://github.com/Hochfrequenz/ahb-tabellen/issues/new"
           title="erfordert einen Github Account"
-          >ein Fehlerticket öffnen.</a
+          >ein Fehlerticket öffnen</a
         >.
       </p>
     </div>


### PR DESCRIPTION
<img width="337" height="127" alt="{BA9548EB-800B-46E4-9120-32374620EEB5}" src="https://github.com/user-attachments/assets/684a5480-61c1-4f08-9770-49f4240629ad" />
