### PR TITLE
feat(filter): Adds filter toggles to the Prüfi overview

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,7 +34,12 @@
       "Bash(npm audit:*)",
       "Bash(npm view:*)",
       "Bash(find:*)",
-      "Bash(mkdir:*)"
+      "Bash(mkdir:*)",
+      "Skill(superpowers:writing-plans)",
+      "Bash(gh pr view:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(gh auth login:*)",
+      "Bash(gh api:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
@@ -23,7 +23,7 @@
           type="button"
           (click)="toggleFilter(toggle)"
           [class.opacity-40]="!toggle.signal()"
-          class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2 hover:ring-offset-1"
+          class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
           [ngClass]="toggle.colorClasses"
           [attr.aria-pressed]="toggle.signal() ? 'true' : 'false'"
           [attr.aria-label]="toggle.title"

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
@@ -14,7 +14,7 @@
 }
 
 <!-- Content -->
-@if (!isLoading && !errorMessage && formatGroups.length > 0) {
+@if (!isLoading && !errorMessage && formatGroups().length > 0) {
   <div>
     <!-- Filter Toggles -->
     <div class="flex flex-wrap items-center gap-2 text-sm mb-4">
@@ -23,7 +23,7 @@
           type="button"
           (click)="toggleFilter(toggle)"
           [class.opacity-40]="!toggle.signal()"
-          class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
+          class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2 hover:ring-offset-1"
           [ngClass]="toggle.colorClasses"
           [attr.aria-pressed]="toggle.signal() ? 'true' : 'false'"
           [attr.aria-label]="toggle.title"
@@ -34,7 +34,7 @@
     </div>
 
     <mat-accordion multi>
-      @for (group of formatGroups; track group.format) {
+      @for (group of formatGroups(); track group.format) {
         <mat-expansion-panel [expanded]="false" class="mat-elevation-z0">
           <mat-expansion-panel-header>
             <mat-panel-title>
@@ -190,7 +190,7 @@
 
 <!-- Empty State -->
 @if (
-  !isLoading && !errorMessage && formatGroups.length === 0 && formatVersionOld && formatVersionNew
+  !isLoading && !errorMessage && formatGroups().length === 0 && formatVersionOld && formatVersionNew
 ) {
   <div class="text-center p-8 bg-white rounded-lg">
     <p class="text-gray-500">Keine Prüfidentifikatoren gefunden.</p>

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
@@ -16,6 +16,23 @@
 <!-- Content -->
 @if (!isLoading && !errorMessage && formatGroups.length > 0) {
   <div>
+    <!-- Filter Toggles -->
+    <div class="flex flex-wrap items-center gap-2 text-sm mb-4">
+      @for (toggle of filterToggles; track toggle.key) {
+        <button
+          type="button"
+          (click)="toggleFilter(toggle)"
+          [class.opacity-40]="!toggle.signal()"
+          class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
+          [ngClass]="toggle.colorClasses"
+          [attr.aria-pressed]="toggle.signal() ? 'true' : 'false'"
+          [attr.aria-label]="toggle.title"
+          [title]="toggle.title">
+          {{ toggle.symbol }}{{ getFilterCount(toggle.key) }}
+        </button>
+      }
+    </div>
+
     <mat-accordion multi>
       @for (group of formatGroups; track group.format) {
         <mat-expansion-panel [expanded]="false" class="mat-elevation-z0">
@@ -45,7 +62,7 @@
               }
             </mat-panel-title>
             <mat-panel-description>
-              {{ group.pruefis.length }} Prüfidentifikatoren
+              {{ getFilteredCount(group) }} / {{ group.pruefis.length }} Prüfidentifikatoren
             </mat-panel-description>
           </mat-expansion-panel-header>
 
@@ -76,7 +93,7 @@
                 </tr>
               </thead>
               <tbody>
-                @for (pruefi of group.pruefis; track pruefi.pruefidentifikator) {
+                @for (pruefi of getFilteredPruefis(group); track pruefi.pruefidentifikator) {
                   <tr class="border-b border-hf-pastell-rose" [ngClass]="getRowClass(pruefi)">
                     <td class="px-3 py-2 text-center">
                       @if (pruefi.status === PruefiStatus.ADDED) {

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.spec.ts
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.spec.ts
@@ -49,7 +49,7 @@ describe('PruefiOverviewComponent', () => {
     });
 
     it('should have empty formatGroups initially', () => {
-      expect(component.formatGroups).toEqual([]);
+      expect(component.formatGroups()).toEqual([]);
     });
 
     it('should not be loading initially', () => {
@@ -141,7 +141,7 @@ describe('PruefiOverviewComponent', () => {
       expect(component.errorMessage).toContain('Fehler beim Laden der Prüfidentifikatoren');
       expect(component.errorMessage).toContain('FV2410');
       expect(component.errorMessage).toContain('FV2504');
-      expect(component.formatGroups).toEqual([]);
+      expect(component.formatGroups()).toEqual([]);
     }));
   });
 
@@ -162,7 +162,7 @@ describe('PruefiOverviewComponent', () => {
       tick();
 
       // Should have UTILMD and MSCONS groups
-      const formatNames = component.formatGroups.map(g => g.format);
+      const formatNames = component.formatGroups().map(g => g.format);
       expect(formatNames).toContain('UTILMD');
       expect(formatNames).toContain('MSCONS');
     }));
@@ -173,7 +173,7 @@ describe('PruefiOverviewComponent', () => {
       fixture.detectChanges();
       tick();
 
-      const utilmdGroup = component.formatGroups.find(g => g.format === 'UTILMD');
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD');
       expect(utilmdGroup).toBeDefined();
 
       // 11003 is added (exists in new, not in old)
@@ -190,7 +190,7 @@ describe('PruefiOverviewComponent', () => {
       fixture.detectChanges();
       tick();
 
-      const utilmdGroup = component.formatGroups.find(g => g.format === 'UTILMD');
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD');
       expect(utilmdGroup).toBeDefined();
 
       // 11002 is removed (exists in old, not in new)
@@ -207,7 +207,7 @@ describe('PruefiOverviewComponent', () => {
       fixture.detectChanges();
       tick();
 
-      const utilmdGroup = component.formatGroups.find(g => g.format === 'UTILMD');
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD');
       expect(utilmdGroup).toBeDefined();
 
       // 11001 is unchanged (exists in both)
@@ -224,7 +224,7 @@ describe('PruefiOverviewComponent', () => {
       fixture.detectChanges();
       tick();
 
-      const utilmdGroup = component.formatGroups.find(g => g.format === 'UTILMD');
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD');
       expect(utilmdGroup).toBeDefined();
       expect(utilmdGroup!.addedCount).toBe(1); // 11003
       expect(utilmdGroup!.removedCount).toBe(1); // 11002
@@ -236,7 +236,7 @@ describe('PruefiOverviewComponent', () => {
       fixture.detectChanges();
       tick();
 
-      const utilmdGroup = component.formatGroups.find(g => g.format === 'UTILMD');
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD');
       const pruefi11001 = utilmdGroup!.pruefis.find(p => p.pruefidentifikator === '11001');
       expect(pruefi11001!.name).toBe('UTILMD Pruefi 1 Updated');
     }));
@@ -247,7 +247,7 @@ describe('PruefiOverviewComponent', () => {
       fixture.detectChanges();
       tick();
 
-      const utilmdGroup = component.formatGroups.find(g => g.format === 'UTILMD');
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD');
       const pruefis = utilmdGroup!.pruefis.map(p => p.pruefidentifikator);
       expect(pruefis).toEqual(['11001', '11002', '11003']);
     }));
@@ -269,7 +269,7 @@ describe('PruefiOverviewComponent', () => {
       tick();
 
       // Should only have 1 pruefi (11001), undefined should be filtered out
-      const utilmdGroup = component.formatGroups.find(g => g.format === 'UTILMD');
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD');
       expect(utilmdGroup!.pruefis.length).toBe(1);
       expect(utilmdGroup!.pruefis[0].pruefidentifikator).toBe('11001');
     }));
@@ -330,5 +330,201 @@ describe('PruefiOverviewComponent', () => {
       const group = { format: 'UTILMD', pruefis: [], addedCount: 0, removedCount: 0 };
       expect(component.hasChanges(group)).toBe(false);
     });
+  });
+
+  describe('toggleFilter', () => {
+    it('should toggle showAdded signal', () => {
+      expect(component.showAdded()).toBe(true);
+      component.toggleFilter(component.filterToggles.find(t => t.key === 'added')!);
+      expect(component.showAdded()).toBe(false);
+      component.toggleFilter(component.filterToggles.find(t => t.key === 'added')!);
+      expect(component.showAdded()).toBe(true);
+    });
+
+    it('should toggle showRemoved signal', () => {
+      expect(component.showRemoved()).toBe(true);
+      component.toggleFilter(component.filterToggles.find(t => t.key === 'removed')!);
+      expect(component.showRemoved()).toBe(false);
+    });
+
+    it('should toggle showChanged signal', () => {
+      expect(component.showChanged()).toBe(true);
+      component.toggleFilter(component.filterToggles.find(t => t.key === 'changed')!);
+      expect(component.showChanged()).toBe(false);
+    });
+
+    it('should toggle showIdentical signal', () => {
+      expect(component.showIdentical()).toBe(true);
+      component.toggleFilter(component.filterToggles.find(t => t.key === 'identical')!);
+      expect(component.showIdentical()).toBe(false);
+    });
+  });
+
+  describe('isPruefiVisible', () => {
+    it('should return showAdded value for ADDED status', () => {
+      const pruefi = {
+        pruefidentifikator: '11001',
+        name: 'Test',
+        existsInOld: false,
+        existsInNew: true,
+        status: PruefiStatus.ADDED,
+      };
+
+      expect(component.isPruefiVisible(pruefi)).toBe(true);
+      component.showAdded.set(false);
+      expect(component.isPruefiVisible(pruefi)).toBe(false);
+    });
+
+    it('should return showRemoved value for REMOVED status', () => {
+      const pruefi = {
+        pruefidentifikator: '11001',
+        name: 'Test',
+        existsInOld: true,
+        existsInNew: false,
+        status: PruefiStatus.REMOVED,
+      };
+
+      expect(component.isPruefiVisible(pruefi)).toBe(true);
+      component.showRemoved.set(false);
+      expect(component.isPruefiVisible(pruefi)).toBe(false);
+    });
+
+    it('should return true for UNCHANGED when diff summary not loaded', () => {
+      const pruefi = {
+        pruefidentifikator: '11001',
+        name: 'Test',
+        existsInOld: true,
+        existsInNew: true,
+        status: PruefiStatus.UNCHANGED,
+      };
+
+      // No diff summary loaded - should show by default
+      expect(component.isPruefiVisible(pruefi)).toBe(true);
+    });
+
+    it('should return showChanged value for UNCHANGED with line changes', () => {
+      const pruefi = {
+        pruefidentifikator: '11001',
+        name: 'Test',
+        existsInOld: true,
+        existsInNew: true,
+        status: PruefiStatus.UNCHANGED,
+      };
+
+      // Set diff summary with changes
+      component.diffSummary.set({ '11001': { added: 1, deleted: 0, modified: 0 } });
+
+      expect(component.isPruefiVisible(pruefi)).toBe(true);
+      component.showChanged.set(false);
+      expect(component.isPruefiVisible(pruefi)).toBe(false);
+    });
+
+    it('should return showIdentical value for UNCHANGED without line changes', () => {
+      const pruefi = {
+        pruefidentifikator: '11001',
+        name: 'Test',
+        existsInOld: true,
+        existsInNew: true,
+        status: PruefiStatus.UNCHANGED,
+      };
+
+      // Set diff summary without changes
+      component.diffSummary.set({ '11001': { added: 0, deleted: 0, modified: 0 } });
+
+      expect(component.isPruefiVisible(pruefi)).toBe(true);
+      component.showIdentical.set(false);
+      expect(component.isPruefiVisible(pruefi)).toBe(false);
+    });
+  });
+
+  describe('getFilteredPruefis', () => {
+    it('should return all pruefis when all filters are enabled', fakeAsync(() => {
+      mockPrufidentifikatorenService.getPruefis.mockImplementation(params => {
+        if (params['format-version'] === 'FV2410') {
+          return of(mockOldPruefis);
+        }
+        return of(mockNewPruefis);
+      });
+
+      fixture.componentRef.setInput('formatVersionOld', 'FV2410');
+      fixture.componentRef.setInput('formatVersionNew', 'FV2504');
+      fixture.detectChanges();
+      tick();
+
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      const filtered = component.getFilteredPruefis(utilmdGroup);
+
+      // All 3 pruefis should be visible (11001 unchanged, 11002 removed, 11003 added)
+      expect(filtered.length).toBe(3);
+    }));
+
+    it('should filter out added pruefis when showAdded is false', fakeAsync(() => {
+      mockPrufidentifikatorenService.getPruefis.mockImplementation(params => {
+        if (params['format-version'] === 'FV2410') {
+          return of(mockOldPruefis);
+        }
+        return of(mockNewPruefis);
+      });
+
+      fixture.componentRef.setInput('formatVersionOld', 'FV2410');
+      fixture.componentRef.setInput('formatVersionNew', 'FV2504');
+      fixture.detectChanges();
+      tick();
+
+      component.showAdded.set(false);
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      const filtered = component.getFilteredPruefis(utilmdGroup);
+
+      // 11003 (added) should be filtered out
+      expect(filtered.find(p => p.pruefidentifikator === '11003')).toBeUndefined();
+      expect(filtered.length).toBe(2);
+    }));
+
+    it('should filter out removed pruefis when showRemoved is false', fakeAsync(() => {
+      mockPrufidentifikatorenService.getPruefis.mockImplementation(params => {
+        if (params['format-version'] === 'FV2410') {
+          return of(mockOldPruefis);
+        }
+        return of(mockNewPruefis);
+      });
+
+      fixture.componentRef.setInput('formatVersionOld', 'FV2410');
+      fixture.componentRef.setInput('formatVersionNew', 'FV2504');
+      fixture.detectChanges();
+      tick();
+
+      component.showRemoved.set(false);
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      const filtered = component.getFilteredPruefis(utilmdGroup);
+
+      // 11002 (removed) should be filtered out
+      expect(filtered.find(p => p.pruefidentifikator === '11002')).toBeUndefined();
+      expect(filtered.length).toBe(2);
+    }));
+  });
+
+  describe('getFilteredCount', () => {
+    it('should return count of visible pruefis', fakeAsync(() => {
+      mockPrufidentifikatorenService.getPruefis.mockImplementation(params => {
+        if (params['format-version'] === 'FV2410') {
+          return of(mockOldPruefis);
+        }
+        return of(mockNewPruefis);
+      });
+
+      fixture.componentRef.setInput('formatVersionOld', 'FV2410');
+      fixture.componentRef.setInput('formatVersionNew', 'FV2504');
+      fixture.detectChanges();
+      tick();
+
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      expect(component.getFilteredCount(utilmdGroup)).toBe(3);
+
+      component.showAdded.set(false);
+      expect(component.getFilteredCount(utilmdGroup)).toBe(2);
+
+      component.showRemoved.set(false);
+      expect(component.getFilteredCount(utilmdGroup)).toBe(1);
+    }));
   });
 });

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
@@ -86,28 +86,31 @@ export class PruefiOverviewComponent implements OnChanges {
       signal: this.showIdentical,
       symbol: '=',
       title: 'Identische Prüfidentifikatoren anzeigen',
-      colorClasses: 'bg-gray-100 text-gray-600 border-gray-400',
+      colorClasses: 'bg-white text-hf-text-color focus:ring-gray-400 hover:ring-gray-400',
     },
     {
       key: 'added',
       signal: this.showAdded,
       symbol: '+',
       title: 'Neue Prüfidentifikatoren anzeigen',
-      colorClasses: 'bg-hf-positive-light text-hf-positive-dark border-hf-positive',
+      colorClasses:
+        'bg-hf-positive-light text-hf-positive-dark focus:ring-hf-positive-dark hover:ring-hf-positive-dark',
     },
     {
       key: 'removed',
       signal: this.showRemoved,
       symbol: '−',
       title: 'Entfernte Prüfidentifikatoren anzeigen',
-      colorClasses: 'bg-hf-negative-light text-hf-negative-dark border-hf-negative',
+      colorClasses:
+        'bg-hf-negative-light text-hf-negative-dark focus:ring-hf-negative-dark hover:ring-hf-negative-dark',
     },
     {
       key: 'changed',
       signal: this.showChanged,
       symbol: '~',
       title: 'Geänderte Prüfidentifikatoren anzeigen',
-      colorClasses: 'bg-hf-neutral-light text-hf-neutral-dark border-hf-neutral',
+      colorClasses:
+        'bg-hf-neutral-light text-hf-neutral-dark focus:ring-hf-neutral-dark hover:ring-hf-neutral-dark',
     },
   ];
 

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
@@ -71,7 +71,7 @@ export class PruefiOverviewComponent implements OnChanges {
 
   isLoading = false;
   errorMessage: string | null = null;
-  formatGroups: FormatGroup[] = [];
+  formatGroups = signal<FormatGroup[]>([]);
   diffSummary = signal<AhbDiffSummary>({});
 
   // Filter visibility states
@@ -111,28 +111,72 @@ export class PruefiOverviewComponent implements OnChanges {
     },
   ];
 
-  // Computed stats for filter counts
+  // Computed stats for filter counts - reacts to both formatGroups and diffSummary changes
   readonly stats = computed(() => {
+    const groups = this.formatGroups();
+    const diffSummary = this.diffSummary();
     let added = 0;
     let removed = 0;
     let changed = 0;
     let identical = 0;
 
-    for (const group of this.formatGroups) {
+    for (const group of groups) {
       for (const pruefi of group.pruefis) {
         if (pruefi.status === PruefiStatus.ADDED) {
           added++;
         } else if (pruefi.status === PruefiStatus.REMOVED) {
           removed++;
-        } else if (this.hasLineChanges(pruefi.pruefidentifikator)) {
-          changed++;
-        } else if (this.hasNoLineChanges(pruefi.pruefidentifikator)) {
-          identical++;
+        } else {
+          // Check line changes using diffSummary directly for proper reactivity
+          const stats = diffSummary[pruefi.pruefidentifikator];
+          if (stats) {
+            if (stats.added > 0 || stats.deleted > 0 || stats.modified > 0) {
+              changed++;
+            } else {
+              identical++;
+            }
+          }
         }
       }
     }
 
     return { added, removed, changed, identical };
+  });
+
+  // Cached filtered pruefis - computed once when signals change, used in template
+  readonly filteredPruefisCache = computed(() => {
+    const groups = this.formatGroups();
+    const diffSummary = this.diffSummary();
+    const showAdded = this.showAdded();
+    const showRemoved = this.showRemoved();
+    const showChanged = this.showChanged();
+    const showIdentical = this.showIdentical();
+
+    const cache = new Map<string, PruefiComparison[]>();
+
+    for (const group of groups) {
+      const filtered = group.pruefis.filter(pruefi => {
+        if (pruefi.status === PruefiStatus.ADDED) {
+          return showAdded;
+        }
+        if (pruefi.status === PruefiStatus.REMOVED) {
+          return showRemoved;
+        }
+        // For unchanged status, check line changes
+        const stats = diffSummary[pruefi.pruefidentifikator];
+        if (stats) {
+          if (stats.added > 0 || stats.deleted > 0 || stats.modified > 0) {
+            return showChanged;
+          }
+          return showIdentical;
+        }
+        // If diff summary not loaded yet, show by default
+        return true;
+      });
+      cache.set(group.format, filtered);
+    }
+
+    return cache;
   });
 
   constructor(private readonly prufidentifikatorenService: PrufidentifikatorenService) {}
@@ -266,7 +310,7 @@ export class PruefiOverviewComponent implements OnChanges {
     // reduce() pass. While this iterates twice, the arrays are small (~10-50 items per format)
     // and the declarative filter approach is more readable. The performance difference is negligible.
     const allFormats = getAllFormats();
-    this.formatGroups = allFormats
+    const groups: FormatGroup[] = allFormats
       .filter(format => formatMap.has(format))
       .map(format => {
         const pruefis = formatMap.get(format)!;
@@ -281,7 +325,7 @@ export class PruefiOverviewComponent implements OnChanges {
     // Add any formats not in the known list (e.g., 'Unbekannt' for unknown prefixes)
     formatMap.forEach((pruefis, format) => {
       if (!allFormats.includes(format)) {
-        this.formatGroups.push({
+        groups.push({
           format,
           pruefis,
           addedCount: pruefis.filter(p => p.status === PruefiStatus.ADDED).length,
@@ -289,6 +333,8 @@ export class PruefiOverviewComponent implements OnChanges {
         });
       }
     });
+
+    this.formatGroups.set(groups);
   }
 
   getRowClass(pruefi: PruefiComparison): string {
@@ -354,10 +400,10 @@ export class PruefiOverviewComponent implements OnChanges {
   }
 
   getFilteredPruefis(group: FormatGroup): PruefiComparison[] {
-    return group.pruefis.filter(pruefi => this.isPruefiVisible(pruefi));
+    return this.filteredPruefisCache().get(group.format) ?? [];
   }
 
   getFilteredCount(group: FormatGroup): number {
-    return this.getFilteredPruefis(group).length;
+    return this.filteredPruefisCache().get(group.format)?.length ?? 0;
   }
 }

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
@@ -1,11 +1,13 @@
 import {
   Component,
+  computed,
   DestroyRef,
   inject,
   Input,
   OnChanges,
   signal,
   SimpleChanges,
+  WritableSignal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
@@ -40,6 +42,16 @@ interface FormatGroup {
   removedCount: number;
 }
 
+type FilterKey = 'added' | 'removed' | 'changed' | 'identical';
+
+interface FilterToggle {
+  key: FilterKey;
+  signal: WritableSignal<boolean>;
+  symbol: string;
+  title: string;
+  colorClasses: string;
+}
+
 @Component({
   selector: 'app-pruefi-overview',
   standalone: true,
@@ -61,6 +73,67 @@ export class PruefiOverviewComponent implements OnChanges {
   errorMessage: string | null = null;
   formatGroups: FormatGroup[] = [];
   diffSummary = signal<AhbDiffSummary>({});
+
+  // Filter visibility states
+  showAdded = signal(true);
+  showRemoved = signal(true);
+  showChanged = signal(true);
+  showIdentical = signal(true);
+
+  readonly filterToggles: FilterToggle[] = [
+    {
+      key: 'identical',
+      signal: this.showIdentical,
+      symbol: '=',
+      title: 'Identische Prüfidentifikatoren anzeigen',
+      colorClasses: 'bg-gray-100 text-gray-600 border-gray-400',
+    },
+    {
+      key: 'added',
+      signal: this.showAdded,
+      symbol: '+',
+      title: 'Neue Prüfidentifikatoren anzeigen',
+      colorClasses: 'bg-hf-positive-light text-hf-positive-dark border-hf-positive',
+    },
+    {
+      key: 'removed',
+      signal: this.showRemoved,
+      symbol: '−',
+      title: 'Entfernte Prüfidentifikatoren anzeigen',
+      colorClasses: 'bg-hf-negative-light text-hf-negative-dark border-hf-negative',
+    },
+    {
+      key: 'changed',
+      signal: this.showChanged,
+      symbol: '~',
+      title: 'Geänderte Prüfidentifikatoren anzeigen',
+      colorClasses: 'bg-hf-neutral-light text-hf-neutral-dark border-hf-neutral',
+    },
+  ];
+
+  // Computed stats for filter counts
+  readonly stats = computed(() => {
+    let added = 0;
+    let removed = 0;
+    let changed = 0;
+    let identical = 0;
+
+    for (const group of this.formatGroups) {
+      for (const pruefi of group.pruefis) {
+        if (pruefi.status === PruefiStatus.ADDED) {
+          added++;
+        } else if (pruefi.status === PruefiStatus.REMOVED) {
+          removed++;
+        } else if (this.hasLineChanges(pruefi.pruefidentifikator)) {
+          changed++;
+        } else if (this.hasNoLineChanges(pruefi.pruefidentifikator)) {
+          identical++;
+        }
+      }
+    }
+
+    return { added, removed, changed, identical };
+  });
 
   constructor(private readonly prufidentifikatorenService: PrufidentifikatorenService) {}
 
@@ -252,5 +325,39 @@ export class PruefiOverviewComponent implements OnChanges {
     const stats = this.diffSummary()[pruefi];
     if (!stats) return false;
     return stats.added > 0 || stats.deleted > 0 || stats.modified > 0;
+  }
+
+  toggleFilter(toggle: FilterToggle): void {
+    toggle.signal.update(v => !v);
+  }
+
+  getFilterCount(key: FilterKey): number {
+    return this.stats()[key];
+  }
+
+  isPruefiVisible(pruefi: PruefiComparison): boolean {
+    if (pruefi.status === PruefiStatus.ADDED) {
+      return this.showAdded();
+    }
+    if (pruefi.status === PruefiStatus.REMOVED) {
+      return this.showRemoved();
+    }
+    // For unchanged status, check if it has line changes
+    if (this.hasLineChanges(pruefi.pruefidentifikator)) {
+      return this.showChanged();
+    }
+    if (this.hasNoLineChanges(pruefi.pruefidentifikator)) {
+      return this.showIdentical();
+    }
+    // If diff summary not loaded yet, show by default
+    return true;
+  }
+
+  getFilteredPruefis(group: FormatGroup): PruefiComparison[] {
+    return group.pruefis.filter(pruefi => this.isPruefiVisible(pruefi));
+  }
+
+  getFilteredCount(group: FormatGroup): number {
+    return this.getFilteredPruefis(group).length;
   }
 }


### PR DESCRIPTION
Implements filter toggles for the Prüfi overview, allowing users to selectively display added, removed, changed, or identical Prüfidentifikatoren.

This enhances the user experience by enabling focused analysis of specific Prüfidentifikator categories.