### PR TITLE
feat: sticky table headers and filters across all views

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -39,7 +39,8 @@
       "Bash(gh pr view:*)",
       "WebFetch(domain:github.com)",
       "Bash(gh auth login:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "Bash(gh pr create:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
@@ -1,4 +1,4 @@
-<div class="relative bg-hf-pastell-rose">
+<div class="relative bg-hf-pastell-rose overflow-x-auto">
   <table class="table-auto w-full min-w-[1000px] text-sm text-hf-text-color">
     <thead #header class="sticky top-0 z-10">
       <tr>

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
@@ -1,110 +1,108 @@
 <div class="relative bg-hf-pastell-rose">
-  <div class="overflow-x-auto">
-    <table class="table-auto w-full text-sm text-hf-text-color">
-      <thead #header>
-        <tr>
-          <th
-            scope="col"
-            class="sticky top-0 bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase transp">
-            Segmentgruppe
-          </th>
-          <th
-            scope="col"
-            class="sticky top-0 bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
-            Segmentname
-          </th>
-          <th
-            scope="col"
-            class="sticky top-0 bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
-            Segment
-          </th>
-          <th
-            scope="col"
-            class="sticky top-0 bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
-            Datenelement
-          </th>
-          <th
-            scope="col"
-            class="sticky top-0 bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
-            Qualifier
-          </th>
-          <th
-            scope="col"
-            class="sticky top-0 bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
-            Name
-          </th>
-          <th
-            scope="col"
-            class="sticky top-0 bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
-            Pflichtfeld-Kennzeichen
-          </th>
-          <th
-            scope="col"
-            class="sticky top-0 bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
-            Bedingung / Hinweis / Format
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        @for (line of lines(); track line.index; let i = $index) {
-          <tr [class]="getRowClass(i)">
-            <td
-              class="px-6 py-4"
-              [class.font-bold]="isSegmentGroup(i)"
-              [innerHTML]="line.segment_group_key | highlight: highlight()"></td>
-            <td
-              class="px-6 py-4"
-              [class.font-bold]="isSegmentGroup(i)"
-              [innerHTML]="line.section_name | highlight: highlight()"></td>
-            <td
-              class="px-6 py-4"
-              [class.font-bold]="isSegmentGroup(i)"
-              [innerHTML]="line.segment_code | highlight: highlight()"></td>
-            <td class="px-6 py-4" [innerHTML]="line.data_element | highlight: highlight()"></td>
-            <td class="px-6 py-4">
-              @if (generateEbdDeepLink(line.value_pool_entry) !== null) {
-                <a
-                  [href]="generateEbdDeepLink(line.value_pool_entry)"
-                  target="_blank"
-                  class="hover:underline font-bold text-hf-dunkel-blau flex flex-row gap-1 items-center">
-                  <span [innerHTML]="line.value_pool_entry | highlight: highlight()"></span>
-                  <app-icon-link />
-                </a>
-              } @else {
+  <table class="table-auto w-full text-sm text-hf-text-color">
+    <thead #header class="sticky top-0 z-10">
+      <tr>
+        <th
+          scope="col"
+          class="bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
+          Segmentgruppe
+        </th>
+        <th
+          scope="col"
+          class="bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
+          Segmentname
+        </th>
+        <th
+          scope="col"
+          class="bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
+          Segment
+        </th>
+        <th
+          scope="col"
+          class="bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
+          Datenelement
+        </th>
+        <th
+          scope="col"
+          class="bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
+          Qualifier
+        </th>
+        <th
+          scope="col"
+          class="bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
+          Name
+        </th>
+        <th
+          scope="col"
+          class="bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
+          Pflichtfeld-Kennzeichen
+        </th>
+        <th
+          scope="col"
+          class="bg-hf-weiss-rose px-6 py-3 text-left text-xs text-hf-text-color uppercase">
+          Bedingung / Hinweis / Format
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (line of lines(); track line.index; let i = $index) {
+        <tr [class]="getRowClass(i)">
+          <td
+            class="px-6 py-4"
+            [class.font-bold]="isSegmentGroup(i)"
+            [innerHTML]="line.segment_group_key | highlight: highlight()"></td>
+          <td
+            class="px-6 py-4"
+            [class.font-bold]="isSegmentGroup(i)"
+            [innerHTML]="line.section_name | highlight: highlight()"></td>
+          <td
+            class="px-6 py-4"
+            [class.font-bold]="isSegmentGroup(i)"
+            [innerHTML]="line.segment_code | highlight: highlight()"></td>
+          <td class="px-6 py-4" [innerHTML]="line.data_element | highlight: highlight()"></td>
+          <td class="px-6 py-4">
+            @if (generateEbdDeepLink(line.value_pool_entry) !== null) {
+              <a
+                [href]="generateEbdDeepLink(line.value_pool_entry)"
+                target="_blank"
+                class="hover:underline font-bold text-hf-dunkel-blau flex flex-row gap-1 items-center">
                 <span [innerHTML]="line.value_pool_entry | highlight: highlight()"></span>
+                <app-icon-link />
+              </a>
+            } @else {
+              <span [innerHTML]="line.value_pool_entry | highlight: highlight()"></span>
+            }
+          </td>
+          <td class="px-6 py-4" [innerHTML]="line.name | highlight: highlight()"></td>
+          <td class="px-6 py-4">
+            @if (line.ahb_expression.includes('[')) {
+              <a
+                [href]="generateBedingungsbaumDeepLink(line.ahb_expression)"
+                target="_blank"
+                class="hover:underline font-bold text-hf-dunkel-gelb flex flex-row gap-1 items-center">
+                {{ line.ahb_expression }} <app-icon-link />
+              </a>
+            } @else {
+              {{ line.ahb_expression }}
+            }
+          </td>
+          <td class="px-6 py-4 conditions-column">
+            @if (line.conditions) {
+              @for (
+                condition of addConditionLineBreaks(getDisplayText(line.conditions, i));
+                track $index
+              ) {
+                <div [innerHTML]="condition | highlight: highlight()"></div>
               }
-            </td>
-            <td class="px-6 py-4" [innerHTML]="line.name | highlight: highlight()"></td>
-            <td class="px-6 py-4">
-              @if (line.ahb_expression.includes('[')) {
-                <a
-                  [href]="generateBedingungsbaumDeepLink(line.ahb_expression)"
-                  target="_blank"
-                  class="hover:underline font-bold text-hf-dunkel-gelb flex flex-row gap-1 items-center">
-                  {{ line.ahb_expression }} <app-icon-link />
-                </a>
-              } @else {
-                {{ line.ahb_expression }}
+              @if (shouldShowToggle(line.conditions)) {
+                <button (click)="toggleExpand(i)" class="text-hf-dunkel-rose text-sm mt-1">
+                  {{ isExpanded(i) ? 'weniger anzeigen' : 'mehr anzeigen' }}
+                </button>
               }
-            </td>
-            <td class="px-6 py-4 conditions-column">
-              @if (line.conditions) {
-                @for (
-                  condition of addConditionLineBreaks(getDisplayText(line.conditions, i));
-                  track $index
-                ) {
-                  <div [innerHTML]="condition | highlight: highlight()"></div>
-                }
-                @if (shouldShowToggle(line.conditions)) {
-                  <button (click)="toggleExpand(i)" class="text-hf-dunkel-rose text-sm mt-1">
-                    {{ isExpanded(i) ? 'weniger anzeigen' : 'mehr anzeigen' }}
-                  </button>
-                }
-              }
-            </td>
-          </tr>
-        }
-      </tbody>
-    </table>
-  </div>
+            }
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
 </div>

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
@@ -1,5 +1,5 @@
 <div class="relative bg-hf-pastell-rose">
-  <table class="table-auto w-full text-sm text-hf-text-color">
+  <table class="table-auto w-full min-w-[1000px] text-sm text-hf-text-color">
     <thead #header class="sticky top-0 z-10">
       <tr>
         <th

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
@@ -1,4 +1,4 @@
-<div class="relative bg-hf-pastell-rose overflow-x-auto">
+<div class="relative bg-hf-pastell-rose">
   <table class="table-auto w-full min-w-[1000px] text-sm text-hf-text-color">
     <thead #header class="sticky top-0 z-10">
       <tr>

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -1,20 +1,20 @@
 <div class="relative bg-hf-pastell-rose">
-  <table class="table-fixed w-full text-xs text-hf-text-color">
+  <table class="table-fixed w-full text-sm text-hf-text-color">
     <thead class="sticky top-11 z-10">
       <tr>
           <th
             [attr.colspan]="showConditionsColumn ? 7 : 6"
-            class="px-2 py-2 text-center text-sm uppercase bg-hf-grell-rose">
+            class="px-2 py-2 text-center text-base uppercase bg-hf-grell-rose">
             Alte Version ({{ formatVersionOld }})
           </th>
           <th class="w-4 bg-hf-pastell-rose"></th>
           <th
             [attr.colspan]="showConditionsColumn ? 7 : 6"
-            class="px-2 py-2 text-center text-sm uppercase bg-hf-grell-rose">
+            class="px-2 py-2 text-center text-base uppercase bg-hf-grell-rose">
             Neue Version ({{ formatVersionNew }})
           </th>
         </tr>
-        <tr class="text-xs">
+        <tr class="text-sm">
           <!-- Old version columns -->
           <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">Seg.grp</th>
           <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">Segment</th>

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -43,31 +43,28 @@
           <tr [class]="getRowClass(line)">
             <!-- Old version columns (version B = old) -->
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
               [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segmentgroup_key')"
-              [title]="getSegmentGroupKey(line, 'old') || '-'">
+              [class]="getChangedColumnClass(line, 'segmentgroup_key')">
               {{ getSegmentGroupKey(line, 'old') || '-' }}
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[60px]"
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
               [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segment_code')"
-              [title]="getSegmentCode(line, 'old') || '-'">
+              [class]="getChangedColumnClass(line, 'segment_code')">
               {{ getSegmentCode(line, 'old') || '-' }}
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[70px]"
-              [class]="getChangedColumnClass(line, 'data_element')"
-              [title]="getDataElement(line, 'old') || '-'">
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
+              [class]="getChangedColumnClass(line, 'data_element')">
               {{ getDataElement(line, 'old') || '-' }}
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
               [class]="getChangedColumnClass(line, 'qualifier')">
               @if (generateEbdDeepLink(getQualifier(line, 'old'), formatVersionOld); as ebdLink) {
-                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')" class="flex items-center gap-0.5">
-                  <span class="truncate">{{ getQualifier(line, 'old') }}</span>
+                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')" class="inline-flex items-center gap-0.5">
+                  <span>{{ getQualifier(line, 'old') }}</span>
                   <app-icon-link class="flex-shrink-0" />
                 </a>
               } @else {
@@ -75,20 +72,19 @@
               }
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[100px]"
-              [class]="getChangedColumnClass(line, 'line_name')"
-              [title]="getName(line, 'old') || '-'">
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
+              [class]="getChangedColumnClass(line, 'line_name')">
               {{ getName(line, 'old') || '-' }}
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
               [class]="getChangedColumnClass(line, 'line_ahb_status')">
               @if (
                 generateBedingungsbaumDeepLink(getAhbStatus(line, 'old'), formatVersionOld);
                 as treeLink
               ) {
-                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')" class="flex items-center gap-0.5">
-                  <span class="truncate">{{ getAhbStatus(line, 'old') }}</span>
+                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')" class="inline-flex items-center gap-0.5">
+                  <span>{{ getAhbStatus(line, 'old') }}</span>
                   <app-icon-link class="flex-shrink-0" />
                 </a>
               } @else {
@@ -96,7 +92,7 @@
               }
             </td>
             @if (showConditionsColumn) {
-              <td class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[120px]" [title]="getHighlightedBedingung(line, 'old')">
+              <td class="px-1 py-1 border-b border-hf-grell-rose break-words">
                 <span [innerHTML]="getHighlightedBedingung(line, 'old')"></span>
               </td>
             }
@@ -106,31 +102,28 @@
 
             <!-- New version columns (version A = new) -->
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
               [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segmentgroup_key')"
-              [title]="getSegmentGroupKey(line, 'new') || '-'">
+              [class]="getChangedColumnClass(line, 'segmentgroup_key')">
               {{ getSegmentGroupKey(line, 'new') || '-' }}
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[60px]"
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
               [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segment_code')"
-              [title]="getSegmentCode(line, 'new') || '-'">
+              [class]="getChangedColumnClass(line, 'segment_code')">
               {{ getSegmentCode(line, 'new') || '-' }}
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[70px]"
-              [class]="getChangedColumnClass(line, 'data_element')"
-              [title]="getDataElement(line, 'new') || '-'">
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
+              [class]="getChangedColumnClass(line, 'data_element')">
               {{ getDataElement(line, 'new') || '-' }}
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
               [class]="getChangedColumnClass(line, 'qualifier')">
               @if (generateEbdDeepLink(getQualifier(line, 'new'), formatVersionNew); as ebdLink) {
-                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')" class="flex items-center gap-0.5">
-                  <span class="truncate">{{ getQualifier(line, 'new') }}</span>
+                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')" class="inline-flex items-center gap-0.5">
+                  <span>{{ getQualifier(line, 'new') }}</span>
                   <app-icon-link class="flex-shrink-0" />
                 </a>
               } @else {
@@ -138,20 +131,19 @@
               }
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[100px]"
-              [class]="getChangedColumnClass(line, 'line_name')"
-              [title]="getName(line, 'new') || '-'">
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
+              [class]="getChangedColumnClass(line, 'line_name')">
               {{ getName(line, 'new') || '-' }}
             </td>
             <td
-              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
+              class="px-1 py-1 border-b border-hf-grell-rose break-words"
               [class]="getChangedColumnClass(line, 'line_ahb_status')">
               @if (
                 generateBedingungsbaumDeepLink(getAhbStatus(line, 'new'), formatVersionNew);
                 as treeLink
               ) {
-                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')" class="flex items-center gap-0.5">
-                  <span class="truncate">{{ getAhbStatus(line, 'new') }}</span>
+                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')" class="inline-flex items-center gap-0.5">
+                  <span>{{ getAhbStatus(line, 'new') }}</span>
                   <app-icon-link class="flex-shrink-0" />
                 </a>
               } @else {
@@ -159,7 +151,7 @@
               }
             </td>
             @if (showConditionsColumn) {
-              <td class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[120px]" [title]="getHighlightedBedingung(line, 'new')">
+              <td class="px-1 py-1 border-b border-hf-grell-rose break-words">
                 <span [innerHTML]="getHighlightedBedingung(line, 'new')"></span>
               </td>
             }

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -1,40 +1,40 @@
 <div class="relative bg-hf-pastell-rose">
-  <table class="table-auto w-full text-sm text-hf-text-color">
+  <table class="table-fixed w-full text-xs text-hf-text-color">
     <thead class="sticky top-11 z-10">
       <tr>
           <th
             [attr.colspan]="showConditionsColumn ? 7 : 6"
-            class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
+            class="px-2 py-2 text-center text-sm uppercase bg-hf-grell-rose">
             Alte Version ({{ formatVersionOld }})
           </th>
-          <th class="w-6 bg-hf-pastell-rose"></th>
+          <th class="w-4 bg-hf-pastell-rose"></th>
           <th
             [attr.colspan]="showConditionsColumn ? 7 : 6"
-            class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
+            class="px-2 py-2 text-center text-sm uppercase bg-hf-grell-rose">
             Neue Version ({{ formatVersionNew }})
           </th>
         </tr>
-        <tr class="text-sm">
+        <tr class="text-xs">
           <!-- Old version columns -->
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Segmentgruppe</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Segment</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Datenelement</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Qualifier</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Name</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Status</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">Seg.grp</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">Segment</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">Datenelem.</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
           @if (showConditionsColumn) {
-            <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Bedingung</th>
+            <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">Beding.</th>
           }
-          <th class="w-6 bg-hf-pastell-rose"></th>
+          <th class="w-4 bg-hf-pastell-rose"></th>
           <!-- New version columns -->
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Segmentgruppe</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Segment</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Datenelement</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Qualifier</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Name</th>
-          <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Status</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">Seg.grp</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">Segment</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">Datenelem.</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
           @if (showConditionsColumn) {
-            <th class="px-3 py-2 text-left bg-hf-sub-header-background-color">Bedingung</th>
+            <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">Beding.</th>
           }
         </tr>
       </thead>
@@ -43,115 +43,123 @@
           <tr [class]="getRowClass(line)">
             <!-- Old version columns (version B = old) -->
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
               [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segmentgroup_key')">
+              [class]="getChangedColumnClass(line, 'segmentgroup_key')"
+              [title]="getSegmentGroupKey(line, 'old') || '-'">
               {{ getSegmentGroupKey(line, 'old') || '-' }}
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[60px]"
               [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segment_code')">
+              [class]="getChangedColumnClass(line, 'segment_code')"
+              [title]="getSegmentCode(line, 'old') || '-'">
               {{ getSegmentCode(line, 'old') || '-' }}
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
-              [class]="getChangedColumnClass(line, 'data_element')">
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[70px]"
+              [class]="getChangedColumnClass(line, 'data_element')"
+              [title]="getDataElement(line, 'old') || '-'">
               {{ getDataElement(line, 'old') || '-' }}
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
               [class]="getChangedColumnClass(line, 'qualifier')">
               @if (generateEbdDeepLink(getQualifier(line, 'old'), formatVersionOld); as ebdLink) {
-                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')">
-                  <span>{{ getQualifier(line, 'old') }}</span>
-                  <app-icon-link />
+                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')" class="flex items-center gap-0.5">
+                  <span class="truncate">{{ getQualifier(line, 'old') }}</span>
+                  <app-icon-link class="flex-shrink-0" />
                 </a>
               } @else {
                 {{ getQualifier(line, 'old') || '-' }}
               }
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
-              [class]="getChangedColumnClass(line, 'line_name')">
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[100px]"
+              [class]="getChangedColumnClass(line, 'line_name')"
+              [title]="getName(line, 'old') || '-'">
               {{ getName(line, 'old') || '-' }}
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
               [class]="getChangedColumnClass(line, 'line_ahb_status')">
               @if (
                 generateBedingungsbaumDeepLink(getAhbStatus(line, 'old'), formatVersionOld);
                 as treeLink
               ) {
-                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')">
-                  <span>{{ getAhbStatus(line, 'old') }}</span>
-                  <app-icon-link />
+                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')" class="flex items-center gap-0.5">
+                  <span class="truncate">{{ getAhbStatus(line, 'old') }}</span>
+                  <app-icon-link class="flex-shrink-0" />
                 </a>
               } @else {
                 {{ getAhbStatus(line, 'old') || '-' }}
               }
             </td>
             @if (showConditionsColumn) {
-              <td class="px-3 py-2 border-b border-hf-grell-rose">
+              <td class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[120px]" [title]="getHighlightedBedingung(line, 'old')">
                 <span [innerHTML]="getHighlightedBedingung(line, 'old')"></span>
               </td>
             }
 
             <!-- Divider -->
-            <td class="bg-hf-pastell-rose"></td>
+            <td class="bg-hf-pastell-rose w-4"></td>
 
             <!-- New version columns (version A = new) -->
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
               [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segmentgroup_key')">
+              [class]="getChangedColumnClass(line, 'segmentgroup_key')"
+              [title]="getSegmentGroupKey(line, 'new') || '-'">
               {{ getSegmentGroupKey(line, 'new') || '-' }}
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[60px]"
               [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segment_code')">
+              [class]="getChangedColumnClass(line, 'segment_code')"
+              [title]="getSegmentCode(line, 'new') || '-'">
               {{ getSegmentCode(line, 'new') || '-' }}
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
-              [class]="getChangedColumnClass(line, 'data_element')">
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[70px]"
+              [class]="getChangedColumnClass(line, 'data_element')"
+              [title]="getDataElement(line, 'new') || '-'">
               {{ getDataElement(line, 'new') || '-' }}
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
               [class]="getChangedColumnClass(line, 'qualifier')">
               @if (generateEbdDeepLink(getQualifier(line, 'new'), formatVersionNew); as ebdLink) {
-                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')">
-                  <span>{{ getQualifier(line, 'new') }}</span>
-                  <app-icon-link />
+                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')" class="flex items-center gap-0.5">
+                  <span class="truncate">{{ getQualifier(line, 'new') }}</span>
+                  <app-icon-link class="flex-shrink-0" />
                 </a>
               } @else {
                 {{ getQualifier(line, 'new') || '-' }}
               }
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
-              [class]="getChangedColumnClass(line, 'line_name')">
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[100px]"
+              [class]="getChangedColumnClass(line, 'line_name')"
+              [title]="getName(line, 'new') || '-'">
               {{ getName(line, 'new') || '-' }}
             </td>
             <td
-              class="px-3 py-2 border-b border-hf-grell-rose"
+              class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[80px]"
               [class]="getChangedColumnClass(line, 'line_ahb_status')">
               @if (
                 generateBedingungsbaumDeepLink(getAhbStatus(line, 'new'), formatVersionNew);
                 as treeLink
               ) {
-                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')">
-                  <span>{{ getAhbStatus(line, 'new') }}</span>
-                  <app-icon-link />
+                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')" class="flex items-center gap-0.5">
+                  <span class="truncate">{{ getAhbStatus(line, 'new') }}</span>
+                  <app-icon-link class="flex-shrink-0" />
                 </a>
               } @else {
                 {{ getAhbStatus(line, 'new') || '-' }}
               }
             </td>
             @if (showConditionsColumn) {
-              <td class="px-3 py-2 border-b border-hf-grell-rose">
+              <td class="px-1 py-1 border-b border-hf-grell-rose truncate max-w-[120px]" [title]="getHighlightedBedingung(line, 'new')">
                 <span [innerHTML]="getHighlightedBedingung(line, 'new')"></span>
               </td>
             }

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -1,5 +1,5 @@
-<div class="relative bg-hf-pastell-rose">
-  <table class="table-fixed w-full text-sm text-hf-text-color">
+<div class="relative bg-hf-pastell-rose overflow-x-auto">
+  <table class="table-fixed w-full min-w-[1200px] text-sm text-hf-text-color">
     <thead class="sticky z-10" style="top: var(--comparison-filter-height)">
       <tr>
         <th

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -16,39 +16,39 @@
       </tr>
       <tr class="text-sm">
         <!-- Old version columns -->
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">
           Seg.grp
         </th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">
           Segment
         </th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">
           Datenelem.
         </th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
         @if (showConditionsColumn) {
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">
+          <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">
             Beding.
           </th>
         }
         <th class="w-4 bg-hf-pastell-rose"></th>
         <!-- New version columns -->
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">
           Seg.grp
         </th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">
           Segment
         </th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">
           Datenelem.
         </th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
-        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
+        <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
         @if (showConditionsColumn) {
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">
+          <th class="px-2 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">
             Beding.
           </th>
         }
@@ -59,24 +59,24 @@
         <tr [class]="getRowClass(line)">
           <!-- Old version columns (version B = old) -->
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class.font-bold]="isSegmentGroup(line)"
             [class]="getChangedColumnClass(line, 'segmentgroup_key')">
             {{ getSegmentGroupKey(line, 'old') || '-' }}
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class.font-bold]="isSegmentGroup(line)"
             [class]="getChangedColumnClass(line, 'segment_code')">
             {{ getSegmentCode(line, 'old') || '-' }}
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'data_element')">
             {{ getDataElement(line, 'old') || '-' }}
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'qualifier')">
             @if (generateEbdDeepLink(getQualifier(line, 'old'), formatVersionOld); as ebdLink) {
               <a
@@ -92,12 +92,12 @@
             }
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'line_name')">
             {{ getName(line, 'old') || '-' }}
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'line_ahb_status')">
             @if (
               generateBedingungsbaumDeepLink(getAhbStatus(line, 'old'), formatVersionOld);
@@ -116,7 +116,7 @@
             }
           </td>
           @if (showConditionsColumn) {
-            <td class="px-1 py-1 border-b border-hf-grell-rose break-words">
+            <td class="px-2 py-1.5 border-b border-hf-grell-rose break-words">
               <span [innerHTML]="getHighlightedBedingung(line, 'old')"></span>
             </td>
           }
@@ -126,24 +126,24 @@
 
           <!-- New version columns (version A = new) -->
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class.font-bold]="isSegmentGroup(line)"
             [class]="getChangedColumnClass(line, 'segmentgroup_key')">
             {{ getSegmentGroupKey(line, 'new') || '-' }}
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class.font-bold]="isSegmentGroup(line)"
             [class]="getChangedColumnClass(line, 'segment_code')">
             {{ getSegmentCode(line, 'new') || '-' }}
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'data_element')">
             {{ getDataElement(line, 'new') || '-' }}
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'qualifier')">
             @if (generateEbdDeepLink(getQualifier(line, 'new'), formatVersionNew); as ebdLink) {
               <a
@@ -159,12 +159,12 @@
             }
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'line_name')">
             {{ getName(line, 'new') || '-' }}
           </td>
           <td
-            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'line_ahb_status')">
             @if (
               generateBedingungsbaumDeepLink(getAhbStatus(line, 'new'), formatVersionNew);
@@ -183,7 +183,7 @@
             }
           </td>
           @if (showConditionsColumn) {
-            <td class="px-1 py-1 border-b border-hf-grell-rose break-words">
+            <td class="px-2 py-1.5 border-b border-hf-grell-rose break-words">
               <span [innerHTML]="getHighlightedBedingung(line, 'new')"></span>
             </td>
           }

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -1,6 +1,6 @@
 <div class="relative bg-hf-pastell-rose">
   <table class="table-fixed w-full text-sm text-hf-text-color">
-    <thead class="sticky top-11 z-10">
+    <thead class="sticky z-10" style="top: var(--comparison-filter-height)">
       <tr>
         <th
           [attr.colspan]="showConditionsColumn ? 7 : 6"

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -1,6 +1,6 @@
 <div class="relative bg-hf-pastell-rose overflow-x-auto">
   <table class="table-fixed w-full min-w-[1200px] text-sm text-hf-text-color">
-    <thead class="sticky z-10" style="top: var(--comparison-filter-height)">
+    <thead class="sticky z-10 sticky-header">
       <tr>
         <th
           [attr.colspan]="showConditionsColumn ? 7 : 6"

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -1,6 +1,6 @@
-<div class="relative bg-hf-pastell-rose overflow-x-auto">
-  <table class="table-fixed w-full min-w-[1200px] text-sm text-hf-text-color">
-    <thead class="sticky z-10 sticky-header">
+<div class="relative bg-hf-pastell-rose">
+  <table class="table-fixed w-full text-sm text-hf-text-color">
+    <thead class="sticky z-10" style="top: var(--comparison-filter-height)">
       <tr>
         <th
           [attr.colspan]="showConditionsColumn ? 7 : 6"

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -2,161 +2,193 @@
   <table class="table-fixed w-full text-sm text-hf-text-color">
     <thead class="sticky top-11 z-10">
       <tr>
-          <th
-            [attr.colspan]="showConditionsColumn ? 7 : 6"
-            class="px-2 py-2 text-center text-base uppercase bg-hf-grell-rose">
-            Alte Version ({{ formatVersionOld }})
+        <th
+          [attr.colspan]="showConditionsColumn ? 7 : 6"
+          class="px-2 py-2 text-center text-base uppercase bg-hf-grell-rose">
+          Alte Version ({{ formatVersionOld }})
+        </th>
+        <th class="w-4 bg-hf-pastell-rose"></th>
+        <th
+          [attr.colspan]="showConditionsColumn ? 7 : 6"
+          class="px-2 py-2 text-center text-base uppercase bg-hf-grell-rose">
+          Neue Version ({{ formatVersionNew }})
+        </th>
+      </tr>
+      <tr class="text-sm">
+        <!-- Old version columns -->
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">
+          Seg.grp
+        </th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">
+          Segment
+        </th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">
+          Datenelem.
+        </th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
+        @if (showConditionsColumn) {
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">
+            Beding.
           </th>
-          <th class="w-4 bg-hf-pastell-rose"></th>
-          <th
-            [attr.colspan]="showConditionsColumn ? 7 : 6"
-            class="px-2 py-2 text-center text-base uppercase bg-hf-grell-rose">
-            Neue Version ({{ formatVersionNew }})
-          </th>
-        </tr>
-        <tr class="text-sm">
-          <!-- Old version columns -->
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">Seg.grp</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">Segment</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">Datenelem.</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
-          @if (showConditionsColumn) {
-            <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">Beding.</th>
-          }
-          <th class="w-4 bg-hf-pastell-rose"></th>
-          <!-- New version columns -->
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">Seg.grp</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">Segment</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">Datenelem.</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
-          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
-          @if (showConditionsColumn) {
-            <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">Beding.</th>
-          }
-        </tr>
-      </thead>
-      <tbody>
-        @for (line of lines; track line.id_path) {
-          <tr [class]="getRowClass(line)">
-            <!-- Old version columns (version B = old) -->
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segmentgroup_key')">
-              {{ getSegmentGroupKey(line, 'old') || '-' }}
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segment_code')">
-              {{ getSegmentCode(line, 'old') || '-' }}
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class]="getChangedColumnClass(line, 'data_element')">
-              {{ getDataElement(line, 'old') || '-' }}
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class]="getChangedColumnClass(line, 'qualifier')">
-              @if (generateEbdDeepLink(getQualifier(line, 'old'), formatVersionOld); as ebdLink) {
-                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')" class="inline-flex items-center gap-0.5">
-                  <span>{{ getQualifier(line, 'old') }}</span>
-                  <app-icon-link class="flex-shrink-0" />
-                </a>
-              } @else {
-                {{ getQualifier(line, 'old') || '-' }}
-              }
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class]="getChangedColumnClass(line, 'line_name')">
-              {{ getName(line, 'old') || '-' }}
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class]="getChangedColumnClass(line, 'line_ahb_status')">
-              @if (
-                generateBedingungsbaumDeepLink(getAhbStatus(line, 'old'), formatVersionOld);
-                as treeLink
-              ) {
-                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')" class="inline-flex items-center gap-0.5">
-                  <span>{{ getAhbStatus(line, 'old') }}</span>
-                  <app-icon-link class="flex-shrink-0" />
-                </a>
-              } @else {
-                {{ getAhbStatus(line, 'old') || '-' }}
-              }
-            </td>
-            @if (showConditionsColumn) {
-              <td class="px-1 py-1 border-b border-hf-grell-rose break-words">
-                <span [innerHTML]="getHighlightedBedingung(line, 'old')"></span>
-              </td>
-            }
-
-            <!-- Divider -->
-            <td class="bg-hf-pastell-rose w-4"></td>
-
-            <!-- New version columns (version A = new) -->
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segmentgroup_key')">
-              {{ getSegmentGroupKey(line, 'new') || '-' }}
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class.font-bold]="isSegmentGroup(line)"
-              [class]="getChangedColumnClass(line, 'segment_code')">
-              {{ getSegmentCode(line, 'new') || '-' }}
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class]="getChangedColumnClass(line, 'data_element')">
-              {{ getDataElement(line, 'new') || '-' }}
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class]="getChangedColumnClass(line, 'qualifier')">
-              @if (generateEbdDeepLink(getQualifier(line, 'new'), formatVersionNew); as ebdLink) {
-                <a [href]="ebdLink" target="_blank" [class]="getLinkClass(line, 'ebd')" class="inline-flex items-center gap-0.5">
-                  <span>{{ getQualifier(line, 'new') }}</span>
-                  <app-icon-link class="flex-shrink-0" />
-                </a>
-              } @else {
-                {{ getQualifier(line, 'new') || '-' }}
-              }
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class]="getChangedColumnClass(line, 'line_name')">
-              {{ getName(line, 'new') || '-' }}
-            </td>
-            <td
-              class="px-1 py-1 border-b border-hf-grell-rose break-words"
-              [class]="getChangedColumnClass(line, 'line_ahb_status')">
-              @if (
-                generateBedingungsbaumDeepLink(getAhbStatus(line, 'new'), formatVersionNew);
-                as treeLink
-              ) {
-                <a [href]="treeLink" target="_blank" [class]="getLinkClass(line, 'bedingung')" class="inline-flex items-center gap-0.5">
-                  <span>{{ getAhbStatus(line, 'new') }}</span>
-                  <app-icon-link class="flex-shrink-0" />
-                </a>
-              } @else {
-                {{ getAhbStatus(line, 'new') || '-' }}
-              }
-            </td>
-            @if (showConditionsColumn) {
-              <td class="px-1 py-1 border-b border-hf-grell-rose break-words">
-                <span [innerHTML]="getHighlightedBedingung(line, 'new')"></span>
-              </td>
-            }
-          </tr>
         }
-      </tbody>
-    </table>
+        <th class="w-4 bg-hf-pastell-rose"></th>
+        <!-- New version columns -->
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segmentgruppe">
+          Seg.grp
+        </th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Segment">
+          Segment
+        </th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Datenelement">
+          Datenelem.
+        </th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Qualifier</th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Name</th>
+        <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color">Status</th>
+        @if (showConditionsColumn) {
+          <th class="px-1 py-1.5 text-left bg-hf-sub-header-background-color" title="Bedingung">
+            Beding.
+          </th>
+        }
+      </tr>
+    </thead>
+    <tbody>
+      @for (line of lines; track line.id_path) {
+        <tr [class]="getRowClass(line)">
+          <!-- Old version columns (version B = old) -->
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class.font-bold]="isSegmentGroup(line)"
+            [class]="getChangedColumnClass(line, 'segmentgroup_key')">
+            {{ getSegmentGroupKey(line, 'old') || '-' }}
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class.font-bold]="isSegmentGroup(line)"
+            [class]="getChangedColumnClass(line, 'segment_code')">
+            {{ getSegmentCode(line, 'old') || '-' }}
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class]="getChangedColumnClass(line, 'data_element')">
+            {{ getDataElement(line, 'old') || '-' }}
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class]="getChangedColumnClass(line, 'qualifier')">
+            @if (generateEbdDeepLink(getQualifier(line, 'old'), formatVersionOld); as ebdLink) {
+              <a
+                [href]="ebdLink"
+                target="_blank"
+                [class]="getLinkClass(line, 'ebd')"
+                class="inline-flex items-center gap-0.5">
+                <span>{{ getQualifier(line, 'old') }}</span>
+                <app-icon-link class="flex-shrink-0" />
+              </a>
+            } @else {
+              {{ getQualifier(line, 'old') || '-' }}
+            }
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class]="getChangedColumnClass(line, 'line_name')">
+            {{ getName(line, 'old') || '-' }}
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class]="getChangedColumnClass(line, 'line_ahb_status')">
+            @if (
+              generateBedingungsbaumDeepLink(getAhbStatus(line, 'old'), formatVersionOld);
+              as treeLink
+            ) {
+              <a
+                [href]="treeLink"
+                target="_blank"
+                [class]="getLinkClass(line, 'bedingung')"
+                class="inline-flex items-center gap-0.5">
+                <span>{{ getAhbStatus(line, 'old') }}</span>
+                <app-icon-link class="flex-shrink-0" />
+              </a>
+            } @else {
+              {{ getAhbStatus(line, 'old') || '-' }}
+            }
+          </td>
+          @if (showConditionsColumn) {
+            <td class="px-1 py-1 border-b border-hf-grell-rose break-words">
+              <span [innerHTML]="getHighlightedBedingung(line, 'old')"></span>
+            </td>
+          }
+
+          <!-- Divider -->
+          <td class="bg-hf-pastell-rose w-4"></td>
+
+          <!-- New version columns (version A = new) -->
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class.font-bold]="isSegmentGroup(line)"
+            [class]="getChangedColumnClass(line, 'segmentgroup_key')">
+            {{ getSegmentGroupKey(line, 'new') || '-' }}
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class.font-bold]="isSegmentGroup(line)"
+            [class]="getChangedColumnClass(line, 'segment_code')">
+            {{ getSegmentCode(line, 'new') || '-' }}
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class]="getChangedColumnClass(line, 'data_element')">
+            {{ getDataElement(line, 'new') || '-' }}
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class]="getChangedColumnClass(line, 'qualifier')">
+            @if (generateEbdDeepLink(getQualifier(line, 'new'), formatVersionNew); as ebdLink) {
+              <a
+                [href]="ebdLink"
+                target="_blank"
+                [class]="getLinkClass(line, 'ebd')"
+                class="inline-flex items-center gap-0.5">
+                <span>{{ getQualifier(line, 'new') }}</span>
+                <app-icon-link class="flex-shrink-0" />
+              </a>
+            } @else {
+              {{ getQualifier(line, 'new') || '-' }}
+            }
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class]="getChangedColumnClass(line, 'line_name')">
+            {{ getName(line, 'new') || '-' }}
+          </td>
+          <td
+            class="px-1 py-1 border-b border-hf-grell-rose break-words"
+            [class]="getChangedColumnClass(line, 'line_ahb_status')">
+            @if (
+              generateBedingungsbaumDeepLink(getAhbStatus(line, 'new'), formatVersionNew);
+              as treeLink
+            ) {
+              <a
+                [href]="treeLink"
+                target="_blank"
+                [class]="getLinkClass(line, 'bedingung')"
+                class="inline-flex items-center gap-0.5">
+                <span>{{ getAhbStatus(line, 'new') }}</span>
+                <app-icon-link class="flex-shrink-0" />
+              </a>
+            } @else {
+              {{ getAhbStatus(line, 'new') || '-' }}
+            }
+          </td>
+          @if (showConditionsColumn) {
+            <td class="px-1 py-1 border-b border-hf-grell-rose break-words">
+              <span [innerHTML]="getHighlightedBedingung(line, 'new')"></span>
+            </td>
+          }
+        </tr>
+      }
+    </tbody>
+  </table>
 </div>

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -1,8 +1,7 @@
 <div class="relative bg-hf-pastell-rose">
-  <div class="overflow-x-auto">
-    <table class="table-auto w-full text-sm text-hf-text-color">
-      <thead>
-        <tr>
+  <table class="table-auto w-full text-sm text-hf-text-color">
+    <thead class="sticky top-11 z-10">
+      <tr>
           <th
             [attr.colspan]="showConditionsColumn ? 7 : 6"
             class="px-3 py-3 text-center text-base uppercase bg-hf-grell-rose">
@@ -160,5 +159,4 @@
         }
       </tbody>
     </table>
-  </div>
 </div>

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.scss
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.scss
@@ -1,0 +1,8 @@
+/*
+ * Sticky header positioning for comparison table.
+ * The top offset must match the filter bar height defined in styles.scss.
+ * See --comparison-filter-height documentation for calculation details.
+ */
+.sticky-header {
+  top: var(--comparison-filter-height);
+}

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -11,6 +11,7 @@ import { getFormatFromPruefi } from '../../../../shared/utils/pruefi-format.util
   standalone: true,
   imports: [CommonModule, IconLinkComponent],
   templateUrl: './comparison-table.component.html',
+  styleUrl: './comparison-table.component.scss',
 })
 export class ComparisonTableComponent {
   @Input() lines: AhbDiffLine[] = [];

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
@@ -19,19 +19,19 @@
     <!-- Filter Toggles (sticky below header) -->
     <div class="sticky top-0 z-10 bg-hf-pastell-rose py-2 -mx-4 px-4 md:-mx-6 md:px-6 mb-2">
       <div class="flex flex-wrap items-center gap-2 text-sm">
-      @for (toggle of filterToggles; track toggle.key) {
-        <button
-          type="button"
-          (click)="toggleFilter(toggle)"
-          [class.opacity-40]="!toggle.signal()"
-          class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
-          [ngClass]="toggle.colorClasses"
-          [attr.aria-pressed]="toggle.signal() ? 'true' : 'false'"
-          [attr.aria-label]="toggle.title"
-          [title]="toggle.title">
-          {{ toggle.symbol }}{{ getFilterCount(toggle.key) }}
-        </button>
-      }
+        @for (toggle of filterToggles; track toggle.key) {
+          <button
+            type="button"
+            (click)="toggleFilter(toggle)"
+            [class.opacity-40]="!toggle.signal()"
+            class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
+            [ngClass]="toggle.colorClasses"
+            [attr.aria-pressed]="toggle.signal() ? 'true' : 'false'"
+            [attr.aria-label]="toggle.title"
+            [title]="toggle.title">
+            {{ toggle.symbol }}{{ getFilterCount(toggle.key) }}
+          </button>
+        }
       </div>
     </div>
 

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
@@ -17,7 +17,7 @@
 @if (!isLoading && !errorMessage && formatGroups().length > 0) {
   <div>
     <!-- Filter Toggles (sticky below header) -->
-    <div class="sticky top-0 z-10 bg-hf-pastell-rose py-2 -mx-4 px-4 md:-mx-6 md:px-6 mb-2">
+    <div class="sticky top-0 z-10 bg-hf-pastell-rose py-2 mb-2">
       <div class="flex flex-wrap items-center gap-2 text-sm">
         @for (toggle of filterToggles; track toggle.key) {
           <button

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
@@ -16,8 +16,9 @@
 <!-- Content -->
 @if (!isLoading && !errorMessage && formatGroups().length > 0) {
   <div>
-    <!-- Filter Toggles -->
-    <div class="flex flex-wrap items-center gap-2 text-sm mb-4">
+    <!-- Filter Toggles (sticky below header) -->
+    <div class="sticky top-0 z-10 bg-hf-pastell-rose py-2 -mx-4 px-4 md:-mx-6 md:px-6 mb-2">
+      <div class="flex flex-wrap items-center gap-2 text-sm">
       @for (toggle of filterToggles; track toggle.key) {
         <button
           type="button"
@@ -31,6 +32,7 @@
           {{ toggle.symbol }}{{ getFilterCount(toggle.key) }}
         </button>
       }
+      </div>
     </div>
 
     <mat-accordion multi>

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
@@ -85,14 +85,14 @@ export class PruefiOverviewComponent implements OnChanges {
       key: 'identical',
       signal: this.showIdentical,
       symbol: '=',
-      title: 'Identische Prüfidentifikatoren anzeigen',
+      title: 'Identische Prüfidentifikatoren ein-/ausblenden',
       colorClasses: 'bg-white text-hf-text-color focus:ring-gray-400 hover:ring-gray-400',
     },
     {
       key: 'added',
       signal: this.showAdded,
       symbol: '+',
-      title: 'Neue Prüfidentifikatoren anzeigen',
+      title: 'Neue Prüfidentifikatoren ein-/ausblenden',
       colorClasses:
         'bg-hf-positive-light text-hf-positive-dark focus:ring-hf-positive-dark hover:ring-hf-positive-dark',
     },
@@ -100,7 +100,7 @@ export class PruefiOverviewComponent implements OnChanges {
       key: 'removed',
       signal: this.showRemoved,
       symbol: '−',
-      title: 'Entfernte Prüfidentifikatoren anzeigen',
+      title: 'Entfernte Prüfidentifikatoren ein-/ausblenden',
       colorClasses:
         'bg-hf-negative-light text-hf-negative-dark focus:ring-hf-negative-dark hover:ring-hf-negative-dark',
     },
@@ -108,7 +108,7 @@ export class PruefiOverviewComponent implements OnChanges {
       key: 'changed',
       signal: this.showChanged,
       symbol: '~',
-      title: 'Geänderte Prüfidentifikatoren anzeigen',
+      title: 'Geänderte Prüfidentifikatoren ein-/ausblenden',
       colorClasses:
         'bg-hf-neutral-light text-hf-neutral-dark focus:ring-hf-neutral-dark hover:ring-hf-neutral-dark',
     },

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.html
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.html
@@ -46,7 +46,8 @@
 
       <!-- Statistics / Filter Toggles (sticky directly below header) -->
       @if (stats(); as stats) {
-        <div class="sticky top-0 z-20 bg-hf-pastell-rose py-2 -mx-4 px-4 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8 mb-2">
+        <div
+          class="sticky top-0 z-20 bg-hf-pastell-rose py-2 -mx-4 px-4 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8 mb-2">
           <div class="flex flex-wrap items-center gap-2 text-sm">
             @for (toggle of filterToggles; track toggle.key) {
               <button

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.html
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.html
@@ -28,11 +28,12 @@
   <!-- Scrollable Content -->
   <div class="flex-1 overflow-auto relative bg-hf-pastell-rose p-6">
     <div class="max-w-screen-2xl mx-auto">
-      <div class="mb-6">
+      <!-- Title and description (scrolls away) -->
+      <div class="mb-4">
         <h1 class="text-2xl font-bold text-hf-text-color mb-1">AHB Vergleich: {{ pruefi() }}</h1>
         @if (description(); as desc) {
           @if (desc.descriptionOld || desc.descriptionNew) {
-            <p class="text-hf-text-color mb-4">
+            <p class="text-hf-text-color">
               @if (desc.descriptionOld === desc.descriptionNew) {
                 {{ desc.descriptionNew }}
               } @else {
@@ -41,9 +42,11 @@
             </p>
           }
         }
+      </div>
 
-        <!-- Statistics / Filter Toggles -->
-        @if (stats(); as stats) {
+      <!-- Statistics / Filter Toggles (sticky below header) -->
+      @if (stats(); as stats) {
+        <div class="sticky top-0 z-20 bg-hf-pastell-rose py-2 -mx-6 px-6 mb-2">
           <div class="flex flex-wrap items-center gap-2 text-sm">
             @for (toggle of filterToggles; track toggle.key) {
               <button
@@ -78,8 +81,8 @@
               Bedingungen
             </button>
           </div>
-        }
-      </div>
+        </div>
+      }
 
       @if (errorOccurred) {
         <div

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.html
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.html
@@ -27,7 +27,7 @@
 
   <!-- Scrollable Content -->
   <div class="flex-1 overflow-auto relative bg-hf-pastell-rose">
-    <div class="max-w-screen-2xl mx-auto px-6 pb-6">
+    <div class="w-full px-4 md:px-6 lg:px-8 pb-6">
       <!-- Title and description (scrolls away) -->
       <div class="mb-4 pt-6">
         <h1 class="text-2xl font-bold text-hf-text-color mb-1">AHB Vergleich: {{ pruefi() }}</h1>
@@ -46,7 +46,7 @@
 
       <!-- Statistics / Filter Toggles (sticky directly below header) -->
       @if (stats(); as stats) {
-        <div class="sticky top-0 z-20 bg-hf-pastell-rose py-2 -mx-6 px-6 mb-2">
+        <div class="sticky top-0 z-20 bg-hf-pastell-rose py-2 -mx-4 px-4 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8 mb-2">
           <div class="flex flex-wrap items-center gap-2 text-sm">
             @for (toggle of filterToggles; track toggle.key) {
               <button

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.html
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.html
@@ -26,10 +26,10 @@
   </app-header>
 
   <!-- Scrollable Content -->
-  <div class="flex-1 overflow-auto relative bg-hf-pastell-rose p-6">
-    <div class="max-w-screen-2xl mx-auto">
+  <div class="flex-1 overflow-auto relative bg-hf-pastell-rose">
+    <div class="max-w-screen-2xl mx-auto px-6 pb-6">
       <!-- Title and description (scrolls away) -->
-      <div class="mb-4">
+      <div class="mb-4 pt-6">
         <h1 class="text-2xl font-bold text-hf-text-color mb-1">AHB Vergleich: {{ pruefi() }}</h1>
         @if (description(); as desc) {
           @if (desc.descriptionOld || desc.descriptionNew) {
@@ -44,7 +44,7 @@
         }
       </div>
 
-      <!-- Statistics / Filter Toggles (sticky below header) -->
+      <!-- Statistics / Filter Toggles (sticky directly below header) -->
       @if (stats(); as stats) {
         <div class="sticky top-0 z-20 bg-hf-pastell-rose py-2 -mx-6 px-6 mb-2">
           <div class="flex flex-wrap items-center gap-2 text-sm">

--- a/src/app/features/comparison/views/comparison-page/comparison-page.component.html
+++ b/src/app/features/comparison/views/comparison-page/comparison-page.component.html
@@ -27,64 +27,64 @@
 
   <!-- Scrollable Content -->
   <div class="flex-1 overflow-auto relative bg-hf-pastell-rose">
-    <div class="w-full px-4 md:px-6 lg:px-8 pb-6">
-      <!-- Title and description (scrolls away) -->
-      <div class="mb-4 pt-6">
-        <h1 class="text-2xl font-bold text-hf-text-color mb-1">AHB Vergleich: {{ pruefi() }}</h1>
-        @if (description(); as desc) {
-          @if (desc.descriptionOld || desc.descriptionNew) {
-            <p class="text-hf-text-color">
-              @if (desc.descriptionOld === desc.descriptionNew) {
-                {{ desc.descriptionNew }}
-              } @else {
-                {{ desc.descriptionOld }} → {{ desc.descriptionNew }}
-              }
-            </p>
-          }
-        }
-      </div>
-
-      <!-- Statistics / Filter Toggles (sticky directly below header) -->
-      @if (stats(); as stats) {
-        <div
-          class="sticky top-0 z-20 bg-hf-pastell-rose py-2 -mx-4 px-4 md:-mx-6 md:px-6 lg:-mx-8 lg:px-8 mb-2">
-          <div class="flex flex-wrap items-center gap-2 text-sm">
-            @for (toggle of filterToggles; track toggle.key) {
-              <button
-                type="button"
-                (click)="toggle.signal.set(!toggle.signal())"
-                [class.opacity-40]="!toggle.signal()"
-                class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
-                [ngClass]="toggle.colorClasses"
-                [attr.aria-pressed]="toggle.signal() ? 'true' : 'false'"
-                [attr.aria-label]="toggle.title"
-                [title]="toggle.title">
-                {{ toggle.symbol }}{{ stats[toggle.key] }}
-              </button>
+    <!-- Title and description (scrolls away) -->
+    <div class="px-4 md:px-6 lg:px-8 pt-6 mb-4">
+      <h1 class="text-2xl font-bold text-hf-text-color mb-1">AHB Vergleich: {{ pruefi() }}</h1>
+      @if (description(); as desc) {
+        @if (desc.descriptionOld || desc.descriptionNew) {
+          <p class="text-hf-text-color">
+            @if (desc.descriptionOld === desc.descriptionNew) {
+              {{ desc.descriptionNew }}
+            } @else {
+              {{ desc.descriptionOld }} → {{ desc.descriptionNew }}
             }
+          </p>
+        }
+      }
+    </div>
 
-            <!-- Divider -->
-            <span class="mx-1 h-6 w-px bg-hf-text-color"></span>
-
-            <!-- Column visibility toggle -->
+    <!-- Statistics / Filter Toggles (sticky directly below header) -->
+    @if (stats(); as stats) {
+      <div class="sticky top-0 z-20 bg-hf-pastell-rose py-2 px-4 md:px-6 lg:px-8 mb-2">
+        <div class="flex flex-wrap items-center gap-2 text-sm">
+          @for (toggle of filterToggles; track toggle.key) {
             <button
               type="button"
-              (click)="showConditionsColumn.set(!showConditionsColumn())"
-              class="px-3 py-1.5 rounded font-medium cursor-pointer transition-all focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
-              [class]="
-                showConditionsColumn()
-                  ? 'bg-hf-dunkel-rose text-white border-hf-dunkel-rose focus:ring-hf-dunkel-rose hover:ring-hf-dunkel-rose'
-                  : 'bg-white text-hf-text-color border-gray-300 focus:ring-gray-400 hover:ring-gray-400'
-              "
-              [attr.aria-pressed]="showConditionsColumn() ? 'true' : 'false'"
-              aria-label="Bedingungen-Spalte ein-/ausblenden"
-              title="Bedingungen-Spalte ein-/ausblenden">
-              Bedingungen
+              (click)="toggle.signal.set(!toggle.signal())"
+              [class.opacity-40]="!toggle.signal()"
+              class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
+              [ngClass]="toggle.colorClasses"
+              [attr.aria-pressed]="toggle.signal() ? 'true' : 'false'"
+              [attr.aria-label]="toggle.title"
+              [title]="toggle.title">
+              {{ toggle.symbol }}{{ stats[toggle.key] }}
             </button>
-          </div>
-        </div>
-      }
+          }
 
+          <!-- Divider -->
+          <span class="mx-1 h-6 w-px bg-hf-text-color"></span>
+
+          <!-- Column visibility toggle -->
+          <button
+            type="button"
+            (click)="showConditionsColumn.set(!showConditionsColumn())"
+            class="px-3 py-1.5 rounded font-medium cursor-pointer transition-all focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2"
+            [class]="
+              showConditionsColumn()
+                ? 'bg-hf-dunkel-rose text-white border-hf-dunkel-rose focus:ring-hf-dunkel-rose hover:ring-hf-dunkel-rose'
+                : 'bg-white text-hf-text-color border-gray-300 focus:ring-gray-400 hover:ring-gray-400'
+            "
+            [attr.aria-pressed]="showConditionsColumn() ? 'true' : 'false'"
+            aria-label="Bedingungen-Spalte ein-/ausblenden"
+            title="Bedingungen-Spalte ein-/ausblenden">
+            Bedingungen
+          </button>
+        </div>
+      </div>
+    }
+
+    <!-- Main content area -->
+    <div class="px-4 md:px-6 lg:px-8 pb-6">
       @if (errorOccurred) {
         <div
           class="text-center p-8 bg-hf-grell-rose text-hf-weiches-schwarz rounded-lg max-w-4xl mx-auto">

--- a/src/app/features/search/components/search-table/search-table.component.html
+++ b/src/app/features/search/components/search-table/search-table.component.html
@@ -1,4 +1,4 @@
-<div class="w-full overflow-x-auto">
+<div class="w-full">
   <mat-table
     [dataSource]="dataSource"
     matSort

--- a/src/app/features/search/components/search-table/search-table.component.html
+++ b/src/app/features/search/components/search-table/search-table.component.html
@@ -1,9 +1,9 @@
-<div class="w-full overflow-x-auto">
+<div class="w-full">
   <mat-table
     [dataSource]="dataSource"
     matSort
     (matSortChange)="onSortChange($event)"
-    class="w-full min-w-[1200px] text-hf-text-color">
+    class="w-full min-w-[1200px] text-hf-text-color sticky-header-table">
     <!-- Format Version Column -->
     <ng-container matColumnDef="format_version">
       <mat-header-cell *matHeaderCellDef mat-sort-header>Formatversion</mat-header-cell>

--- a/src/app/features/search/components/search-table/search-table.component.html
+++ b/src/app/features/search/components/search-table/search-table.component.html
@@ -1,4 +1,4 @@
-<div class="w-full">
+<div class="w-full overflow-x-auto">
   <mat-table
     [dataSource]="dataSource"
     matSort

--- a/src/app/features/search/components/search-table/search-table.component.scss
+++ b/src/app/features/search/components/search-table/search-table.component.scss
@@ -11,6 +11,13 @@
   border-bottom: 2px solid #e0e0e0;
 }
 
+// Sticky header at top of scroll container
+.sticky-header-table .mat-mdc-header-row {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
 .mat-mdc-row:hover {
   background-color: #cbafaf;
 }

--- a/src/app/features/search/views/search-page/search-page.component.html
+++ b/src/app/features/search/views/search-page/search-page.component.html
@@ -39,8 +39,10 @@
           </h2>
         </div>
       </div>
+    </div>
 
-      <!-- Search Results Table (header sticks to top) -->
+    <!-- Search Results Table (header sticks to top) -->
+    <div class="search-page !pt-0">
       <div *ngIf="loading" class="loading-container">
         <mat-spinner diameter="40"></mat-spinner>
         <p>Suche läuft…</p>
@@ -61,7 +63,9 @@
         (pageSizeChange)="onPageSizeChange($event)"
         (sortChange)="onSortChange($event)">
       </app-search-table>
+    </div>
 
+    <div class="search-page !pt-0">
       <!-- Solutions footer inside scroll: visible only on small screens -->
       <app-solutions-footer class="block md:hidden"></app-solutions-footer>
     </div>

--- a/src/app/features/search/views/search-page/search-page.component.html
+++ b/src/app/features/search/views/search-page/search-page.component.html
@@ -55,13 +55,13 @@
 
       <app-search-table
         *ngIf="searchResults && !loading && !error"
-          [data]="searchResults.items || []"
-          [totalItems]="searchResults.total || 0"
-          [page]="searchResults.page || 1"
-          [pageSize]="searchResults.pageSize || 25"
-          (pageChange)="onPageChange($event)"
-          (pageSizeChange)="onPageSizeChange($event)"
-          (sortChange)="onSortChange($event)">
+        [data]="searchResults.items || []"
+        [totalItems]="searchResults.total || 0"
+        [page]="searchResults.page || 1"
+        [pageSize]="searchResults.pageSize || 25"
+        (pageChange)="onPageChange($event)"
+        (pageSizeChange)="onPageSizeChange($event)"
+        (sortChange)="onSortChange($event)">
       </app-search-table>
     </div>
 

--- a/src/app/features/search/views/search-page/search-page.component.html
+++ b/src/app/features/search/views/search-page/search-page.component.html
@@ -39,10 +39,9 @@
           </h2>
         </div>
       </div>
-    </div>
 
-    <!-- Search Results Table (header sticks to top) -->
-    <div class="search-page !pt-0">
+      <!-- Search Results Table (header sticks to top) -->
+
       <div *ngIf="loading" class="loading-container">
         <mat-spinner diameter="40"></mat-spinner>
         <p>Suche läuft…</p>
@@ -63,9 +62,7 @@
         (pageSizeChange)="onPageSizeChange($event)"
         (sortChange)="onSortChange($event)">
       </app-search-table>
-    </div>
 
-    <div class="search-page !pt-0">
       <!-- Solutions footer inside scroll: visible only on small screens -->
       <app-solutions-footer class="block md:hidden"></app-solutions-footer>
     </div>

--- a/src/app/features/search/views/search-page/search-page.component.html
+++ b/src/app/features/search/views/search-page/search-page.component.html
@@ -39,10 +39,8 @@
           </h2>
         </div>
       </div>
-    </div>
 
-    <!-- Search Results Table (header sticks to top) -->
-    <div class="search-page !pt-0">
+      <!-- Search Results Table (header sticks to top) -->
       <div *ngIf="loading" class="loading-container">
         <mat-spinner diameter="40"></mat-spinner>
         <p>Suche läuft…</p>
@@ -63,9 +61,7 @@
         (pageSizeChange)="onPageSizeChange($event)"
         (sortChange)="onSortChange($event)">
       </app-search-table>
-    </div>
 
-    <div class="search-page !pt-0">
       <!-- Solutions footer inside scroll: visible only on small screens -->
       <app-solutions-footer class="block md:hidden"></app-solutions-footer>
     </div>

--- a/src/app/features/search/views/search-page/search-page.component.html
+++ b/src/app/features/search/views/search-page/search-page.component.html
@@ -29,41 +29,43 @@
           </mat-card-content>
         </mat-card>
 
-        <!-- Search Results -->
-        <mat-card class="results-card">
-          <mat-card-header>
-            <mat-card-title>
-              Ergebnisse
-              <span *ngIf="searchResults" class="result-count">
-                ({{ searchResults.total }} items)
-              </span>
-            </mat-card-title>
-          </mat-card-header>
-          <mat-card-content>
-            <div *ngIf="loading" class="loading-container">
-              <mat-spinner diameter="40"></mat-spinner>
-              <p>Suche läuft…</p>
-            </div>
+        <!-- Search Results Header (scrolls away) -->
+        <div class="results-header">
+          <h2 class="text-xl font-medium text-hf-text-color">
+            Ergebnisse
+            <span *ngIf="searchResults" class="result-count">
+              ({{ searchResults.total }} items)
+            </span>
+          </h2>
+        </div>
+      </div>
+    </div>
 
-            <div *ngIf="error" class="error-container">
-              <mat-icon color="warn" fontSet="mdi" fontIcon="mdi-alert"></mat-icon>
-              <p>{{ error }}</p>
-            </div>
-
-            <app-search-table
-              *ngIf="searchResults && !loading && !error"
-              [data]="searchResults.items || []"
-              [totalItems]="searchResults.total || 0"
-              [page]="searchResults.page || 1"
-              [pageSize]="searchResults.pageSize || 25"
-              (pageChange)="onPageChange($event)"
-              (pageSizeChange)="onPageSizeChange($event)"
-              (sortChange)="onSortChange($event)">
-            </app-search-table>
-          </mat-card-content>
-        </mat-card>
+    <!-- Search Results Table (header sticks to top) -->
+    <div class="search-page !pt-0">
+      <div *ngIf="loading" class="loading-container">
+        <mat-spinner diameter="40"></mat-spinner>
+        <p>Suche läuft…</p>
       </div>
 
+      <div *ngIf="error" class="error-container">
+        <mat-icon color="warn" fontSet="mdi" fontIcon="mdi-alert"></mat-icon>
+        <p>{{ error }}</p>
+      </div>
+
+      <app-search-table
+        *ngIf="searchResults && !loading && !error"
+          [data]="searchResults.items || []"
+          [totalItems]="searchResults.total || 0"
+          [page]="searchResults.page || 1"
+          [pageSize]="searchResults.pageSize || 25"
+          (pageChange)="onPageChange($event)"
+          (pageSizeChange)="onPageSizeChange($event)"
+          (sortChange)="onSortChange($event)">
+      </app-search-table>
+    </div>
+
+    <div class="search-page !pt-0">
       <!-- Solutions footer inside scroll: visible only on small screens -->
       <app-solutions-footer class="block md:hidden"></app-solutions-footer>
     </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,9 +13,19 @@
 }
 
 :root {
-  /* Sticky positioning offsets for comparison page */
-  /* Filter bar height: py-2 (16px) + button height (~28px) = ~44px */
-  --comparison-filter-height: 2.75rem; /* 44px - matches filter toggle bar height */
+  /*
+   * Sticky positioning offset for comparison table header.
+   * This value must match the height of the filter toggle bar in comparison-page.component.html.
+   *
+   * Calculation: py-2 (0.5rem × 2 = 1rem = 16px) + button height (~28px) = ~44px = 2.75rem
+   *
+   * Dependencies:
+   * - Used by: comparison-table.component.html (thead sticky top offset)
+   * - Defined by: comparison-page.component.html (filter bar with class "py-2")
+   *
+   * If the filter bar padding or button size changes, update this value accordingly.
+   */
+  --comparison-filter-height: 2.75rem;
 
   /* copied from /assets/companystylesheet/css/hochfrequenz.css, because I didn't manage to import/include it properly */
   /* X [ERROR] Could not resolve "/assets/companystylesheet/css/hochfrequenz.css" */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,10 @@
 }
 
 :root {
+  /* Sticky positioning offsets for comparison page */
+  /* Filter bar height: py-2 (16px) + button height (~28px) = ~44px */
+  --comparison-filter-height: 2.75rem; /* 44px - matches filter toggle bar height */
+
   /* copied from /assets/companystylesheet/css/hochfrequenz.css, because I didn't manage to import/include it properly */
   /* X [ERROR] Could not resolve "/assets/companystylesheet/css/hochfrequenz.css" */
   /* Greens, lind-grün, oben rechts */


### PR DESCRIPTION
## Summary

- **AHB Table**: Make table header sticky when scrolling through AHB content
- **Prüfi Overview**: Make filter toggles sticky below the top header
- **Comparison Page**: Make filter toggles and both table header rows (ALTE/NEUE VERSION + column headers) sticky
- **Search Page**: Make search results table header sticky at the top

All sticky elements position themselves directly below the main header without gaps, keeping important navigation and context visible while scrolling through large datasets.

## Changes

- `ahb-table.component.html`: Added `sticky top-0 z-10` to thead
- `pruefi-overview.component.html`: Wrapped filters in sticky container
- `comparison-page.component.html`: Restructured padding, made filters sticky at top-0
- `comparison-table.component.html`: Made thead sticky at top-11 (below filters)
- `search-page.component.html`: Restructured layout to allow table header to stick
- `search-table.component.scss`: Added sticky positioning for mat-header-row

## Test plan

- [ ] Verify AHB table header stays visible when scrolling
- [ ] Verify prüfi overview filters stick below header
- [ ] Verify comparison page filters and table headers stick without gaps
- [ ] Verify search results table header sticks at top
- [ ] Test horizontal scrolling still works on comparison and search tables
- [ ] Test on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)