### PR TITLE
infra: Reverts app service plan SKU to B1

### DIFF
--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -1,6 +1,6 @@
 config:
   ahb-tabellen:appPath: app
-  ahb-tabellen:appServicePlanSkuName: "B2"
+  ahb-tabellen:appServicePlanSkuName: "B1"
   ahb-tabellen:appServicePlanSkuTier: "Basic"
   ahb-tabellen:bedingungsbaumBaseUrl: https://bedingungsbaum.stage.hochfrequenz.de
   ahb-tabellen:containerPort: "80"


### PR DESCRIPTION
Reduces the app service plan SKU size from B2 back to B1.

This change aims to lower costs and aligns with the application's current resource requirements.
