### PR TITLE
fix: page size dropdown now correctly updates search results

### DIFF
--- a/src/app/features/search/components/search-table/search-table.component.spec.ts
+++ b/src/app/features/search/components/search-table/search-table.component.spec.ts
@@ -125,6 +125,30 @@ describe('SearchTableComponent', () => {
     });
   });
 
+  describe('onPageChange', () => {
+    it('should emit pageChange when only page index changes', () => {
+      const pageChangeSpy = jest.spyOn(component.pageChange, 'emit');
+      const pageSizeChangeSpy = jest.spyOn(component.pageSizeChange, 'emit');
+
+      const event = { pageIndex: 2, pageSize: 25, length: 100 };
+      component.onPageChange(event);
+
+      expect(pageChangeSpy).toHaveBeenCalledWith(event);
+      expect(pageSizeChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should emit pageSizeChange when pageSize changes', () => {
+      const pageChangeSpy = jest.spyOn(component.pageChange, 'emit');
+      const pageSizeChangeSpy = jest.spyOn(component.pageSizeChange, 'emit');
+
+      const event = { pageIndex: 0, pageSize: 50, length: 100 };
+      component.onPageChange(event);
+
+      expect(pageSizeChangeSpy).toHaveBeenCalledWith(event);
+      expect(pageChangeSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('onPruefidentifikatorClick', () => {
     let windowOpenSpy: jest.SpyInstance;
 

--- a/src/app/features/search/components/search-table/search-table.component.ts
+++ b/src/app/features/search/components/search-table/search-table.component.ts
@@ -58,7 +58,11 @@ export class SearchTableComponent implements OnChanges {
   }
 
   onPageChange(event: PageEvent): void {
-    this.pageChange.emit(event);
+    if (event.pageSize !== this.pageSize) {
+      this.pageSizeChange.emit(event);
+    } else {
+      this.pageChange.emit(event);
+    }
   }
 
   onSortChange(event: Sort): void {


### PR DESCRIPTION
The page size dropdown in the global search (Globale Suche) was resetting to 25 items whenever a different option was selected.

Root cause: MatPaginator emits a single PageEvent for both page navigation and page size changes. The onPageChange handler in SearchTableComponent was always emitting to pageChange, which only updated the page index in the SearchService - ignoring the pageSize value entirely. This caused the search to re-run with the old pageSize (25), and the response would reset the paginator back to 25.

Fix: Check if event.pageSize differs from the current pageSize input. If so, emit to pageSizeChange (which calls SearchService.updatePageSize). Otherwise, emit to pageChange for normal page navigation.

Closes #771