### PR TITLE
fix: handle German umlauts in case-insensitive search

### DIFF
--- a/src/server/repository/ahb.spec.ts
+++ b/src/server/repository/ahb.spec.ts
@@ -368,7 +368,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should use "44%" pattern (starts with 44)
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.'),
         expect.objectContaining({ q0: '44%' })
       );
     });
@@ -384,7 +384,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should use "%foo" pattern (ends with foo)
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.'),
         expect.objectContaining({ q0: '%foo' })
       );
     });
@@ -400,7 +400,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should use "Konfig%-ID" pattern
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.'),
         expect.objectContaining({ q0: 'konfig%-id' })
       );
     });
@@ -416,7 +416,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should convert all * to %
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.'),
         expect.objectContaining({ q0: '%foo%bar%' })
       );
     });
@@ -432,7 +432,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should use "%foo%" pattern (substring match - backward compatible)
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.'),
         expect.objectContaining({ q0: '%foo%' })
       );
     });
@@ -448,7 +448,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should escape % as \% and convert * to %
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.'),
         expect.objectContaining({ q0: '100\\%%' })
       );
     });
@@ -464,7 +464,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should escape _ as \_ (SQL single char wildcard) and convert * to %
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.'),
         expect.objectContaining({ q0: 'foo\\_bar%' })
       );
     });
@@ -480,7 +480,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should lowercase the pattern
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.'),
         expect.objectContaining({ q0: 'foo%bar' })
       );
     });
@@ -500,7 +500,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should use "44%" pattern (starts with 44)
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.pruefidentifikator) LIKE'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.pruefidentifikator)'),
         expect.objectContaining({ f_pruefidentifikator_contains: '44%' })
       );
     });
@@ -518,7 +518,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should use "%44%" pattern (substring match)
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.pruefidentifikator) LIKE'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.pruefidentifikator)'),
         expect.objectContaining({ f_pruefidentifikator_contains: '%44%' })
       );
     });
@@ -536,7 +536,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should escape % as \%, _ as \_, and convert * to %
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.line_name) LIKE'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.line_name)'),
         expect.objectContaining({ f_line_name_contains: '100\\%\\_test%' })
       );
     });
@@ -554,7 +554,7 @@ describe('AHBRepository - Sender and Empfaenger Filters', () => {
 
       // Should use "konfig%-id" pattern
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(al.line_name) LIKE'),
+        expect.stringContaining('REPLACE(REPLACE(REPLACE(LOWER(al.line_name)'),
         expect.objectContaining({ f_line_name_contains: 'konfig%-id' })
       );
     });

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -105,6 +105,15 @@ export default class AHBRepository {
       return field;
     };
 
+    // SQLite's LOWER() only handles ASCII — LOWER('Ä') returns 'Ä', not 'ä'.
+    // We wrap with REPLACE to normalize German umlauts so that case-insensitive
+    // search works for both 'Änderung' and 'änderung'.
+    // The JS side uses .toLowerCase() which handles Unicode correctly, so both sides
+    // produce consistent lowercase output including umlauts.
+    // See: https://github.com/Hochfrequenz/ahb-tabellen/issues/790
+    const unicodeLower = (expr: string): string =>
+      `REPLACE(REPLACE(REPLACE(LOWER(${expr}), 'Ä', 'ä'), 'Ö', 'ö'), 'Ü', 'ü')`;
+
     // Helper function to convert user wildcard patterns to SQL LIKE patterns
     // - If user enters "*", replace with "%" for SQL wildcard
     // - If no "*" is present, wrap with "%" for implicit substring matching
@@ -184,17 +193,17 @@ export default class AHBRepository {
           );
         }
         if (value.contains !== undefined) {
-          queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_contains ESCAPE '\\'`, {
+          queryBuilder.andWhere(`${unicodeLower('al.' + columnName)} LIKE :${paramBase}_contains ESCAPE '\\'`, {
             [`${paramBase}_contains`]: convertToLikePattern(value.contains),
           });
         }
         if (value.startsWith !== undefined) {
-          queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_starts`, {
+          queryBuilder.andWhere(`${unicodeLower('al.' + columnName)} LIKE :${paramBase}_starts`, {
             [`${paramBase}_starts`]: `${value.startsWith.toLowerCase()}%`,
           });
         }
         if (value.endsWith !== undefined) {
-          queryBuilder.andWhere(`LOWER(al.${columnName}) LIKE :${paramBase}_ends`, {
+          queryBuilder.andWhere(`${unicodeLower('al.' + columnName)} LIKE :${paramBase}_ends`, {
             [`${paramBase}_ends`]: `%${value.endsWith.toLowerCase()}`,
           });
         }
@@ -261,7 +270,7 @@ export default class AHBRepository {
         // Include ESCAPE clause for SQLite to recognize backslash as escape character
         const orConditions = qFields.map((field, idx) => {
           const columnName = validateField(field);
-          return `LOWER(al.${columnName}) LIKE :q${idx} ESCAPE '\\'`;
+          return `${unicodeLower('al.' + columnName)} LIKE :q${idx} ESCAPE '\\'`;
         });
 
         const params = Object.fromEntries(qFields.map((_, idx) => [`q${idx}`, likePattern]));

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -193,9 +193,12 @@ export default class AHBRepository {
           );
         }
         if (value.contains !== undefined) {
-          queryBuilder.andWhere(`${unicodeLower('al.' + columnName)} LIKE :${paramBase}_contains ESCAPE '\\'`, {
-            [`${paramBase}_contains`]: convertToLikePattern(value.contains),
-          });
+          queryBuilder.andWhere(
+            `${unicodeLower('al.' + columnName)} LIKE :${paramBase}_contains ESCAPE '\\'`,
+            {
+              [`${paramBase}_contains`]: convertToLikePattern(value.contains),
+            }
+          );
         }
         if (value.startsWith !== undefined) {
           queryBuilder.andWhere(`${unicodeLower('al.' + columnName)} LIKE :${paramBase}_starts`, {


### PR DESCRIPTION
Closes #790

## Problem

Searching for "Änderung Daten der MaLo" returns no results, but "nderung Daten der MaLo" works.

**Root cause:** SQLite's `LOWER()` only handles ASCII. `LOWER('Ä')` returns `'Ä'` (unchanged), but JavaScript's `.toLowerCase()` correctly returns `'ä'`. The search compares `LOWER(column)` (SQL, keeps Ä) against the JS-lowered pattern (ä) — mismatch, no results.

## Fix

Wrap `LOWER()` with `REPLACE()` to normalize German umlauts on the SQL side:

```typescript
const unicodeLower = (expr: string): string =>
  `REPLACE(REPLACE(REPLACE(LOWER(${expr}), 'Ä', 'ä'), 'Ö', 'ö'), 'Ü', 'ü')`;
```

No DB changes needed — substring search (`%pattern%`) always does a full table scan regardless, so expression indexes are irrelevant here (confirmed by DB expert review).

## Tested

Verified against the unencrypted production DB (v2026.03.27.4):
- `'Änderung Daten der MaLo'` → 1240 matches (was 0)
- `'änderung daten der malo'` → 1240 matches (was 0)
- `'Übersicht'` → 1072 matches (was 0)
- `'Übermittlung'` → 8118 matches (was 0)
- ASCII search still works: `'Berechnungsformel'` → 801 matches