### PR TITLE
feat: replace hardcoded EDIFACT logic with @hochfrequenz/efoli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser-dynamic": "^19.2.17",
         "@angular/router": "^19.2.17",
         "@auth0/auth0-angular": "^2.2.3",
+        "@hochfrequenz/efoli": "^0.0.8",
         "@mdi/font": "^7.4.47",
         "cors": "^2.8.5",
         "diff": "^8.0.2",
@@ -3559,6 +3560,15 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@hochfrequenz/efoli": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@hochfrequenz/efoli/-/efoli-0.0.8.tgz",
+      "integrity": "sha512-fQlkPvJqs3XUZ8e6nS/mDQKHfo1JkCpC1/WI8KJJPqGuwto77lMSXrRELIteW8RhLS0magC4bKzB9gxhIDvXdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@angular/platform-browser-dynamic": "^19.2.17",
     "@angular/router": "^19.2.17",
     "@auth0/auth0-angular": "^2.2.3",
+    "@hochfrequenz/efoli": "^0.0.8",
     "@mdi/font": "^7.4.47",
     "cors": "^2.8.5",
     "diff": "^8.0.2",

--- a/src/app/features/ahbs/components/format-version-select/format-version-select.component.ts
+++ b/src/app/features/ahbs/components/format-version-select/format-version-select.component.ts
@@ -87,10 +87,10 @@ export class FormatVersionSelectComponent implements ControlValueAccessor, OnIni
   }
 
   private getFormatVersionLabel(formatVersion: string): string {
-    try {
+    const knownVersions = Object.values(EdifactFormatVersion) as string[];
+    if (knownVersions.includes(formatVersion)) {
       return getEdifactFormatVersionLabel(formatVersion as EdifactFormatVersion);
-    } catch {
-      return formatVersion;
     }
+    return formatVersion;
   }
 }

--- a/src/app/features/ahbs/components/format-version-select/format-version-select.component.ts
+++ b/src/app/features/ahbs/components/format-version-select/format-version-select.component.ts
@@ -9,7 +9,11 @@ import {
 import { FormatVersionsService } from '../../../../core/api';
 import { Observable, map, tap } from 'rxjs';
 import { CommonModule } from '@angular/common';
-import { getCurrentEdifactFormatVersion, getEdifactFormatVersionLabel, EdifactFormatVersion } from '@hochfrequenz/efoli';
+import {
+  getCurrentEdifactFormatVersion,
+  getEdifactFormatVersionLabel,
+  EdifactFormatVersion,
+} from '@hochfrequenz/efoli';
 
 @Component({
   selector: 'app-format-version-select',

--- a/src/app/features/ahbs/components/format-version-select/format-version-select.component.ts
+++ b/src/app/features/ahbs/components/format-version-select/format-version-select.component.ts
@@ -9,6 +9,7 @@ import {
 import { FormatVersionsService } from '../../../../core/api';
 import { Observable, map, tap } from 'rxjs';
 import { CommonModule } from '@angular/common';
+import { getCurrentEdifactFormatVersion, getEdifactFormatVersionLabel, EdifactFormatVersion } from '@hochfrequenz/efoli';
 
 @Component({
   selector: 'app-format-version-select',
@@ -38,12 +39,12 @@ export class FormatVersionSelectComponent implements ControlValueAccessor, OnIni
       map(versions =>
         versions.map(v => ({
           value: v,
-          label: this.getFormatVersionDate(v),
+          label: this.getFormatVersionLabel(v),
         }))
       ),
       tap(() => {
         if (!this.control.value) {
-          const defaultVersion = this.getDefaultFormatVersion();
+          const defaultVersion = getCurrentEdifactFormatVersion();
           this.control.setValue(defaultVersion);
           if (this.onChange) {
             this.onChange(defaultVersion);
@@ -61,30 +62,6 @@ export class FormatVersionSelectComponent implements ControlValueAccessor, OnIni
     });
   }
 
-  /**
-   * Returns the default format version based on a series of predefined datetime upper thresholds.
-   * Each threshold corresponds to a specific version of the Edifact format.
-   * The thresholds are defined in UTC and are based on the official BDEW schedule.
-   */
-  private getDefaultFormatVersion(): string {
-    const now = new Date();
-    const formatVersionThresholds: [Date, string][] = [
-      [new Date('2024-09-30T22:00:00Z'), 'FV2404'],
-      [new Date('2025-06-05T22:00:00Z'), 'FV2410'],
-      [new Date('2025-09-30T22:00:00Z'), 'FV2504'],
-      [new Date('2026-03-31T22:00:00Z'), 'FV2510'],
-      [new Date('2026-09-30T22:00:00Z'), 'FV2604'],
-      [new Date('2027-03-31T22:00:00Z'), 'FV2610'],
-    ];
-
-    for (const [thresholdDate, version] of formatVersionThresholds) {
-      if (now < thresholdDate) {
-        return version;
-      }
-    }
-
-    return 'FV2604';
-  }
   writeValue(formatVersion: string): void {
     this.control.setValue(formatVersion);
   }
@@ -105,21 +82,11 @@ export class FormatVersionSelectComponent implements ControlValueAccessor, OnIni
     }
   }
 
-  private getFormatVersionDate(formatVersion: string): string {
-    const mapping: { [key: string]: string } = {
-      FV2104: 'April 2021 (FV2104)',
-      FV2110: 'Oktober 2021 (FV2110)',
-      FV2204: 'April 2022 (FV2204)',
-      FV2210: 'Oktober 2022 (FV2210)',
-      FV2304: 'April 2023 (FV2304)',
-      FV2310: 'Oktober 2023 (FV2310)',
-      FV2404: 'April 2024 (FV2404)',
-      FV2410: 'Oktober 2024 (FV2410)',
-      FV2504: 'Juni 2025 (FV2504)',
-      FV2510: 'Oktober 2025 (FV2510)',
-      FV2604: 'April 2026 (FV2604)',
-      FV2610: 'Oktober 2026 (FV2610)',
-    };
-    return mapping[formatVersion] || formatVersion;
+  private getFormatVersionLabel(formatVersion: string): string {
+    try {
+      return getEdifactFormatVersionLabel(formatVersion as EdifactFormatVersion);
+    } catch {
+      return formatVersion;
+    }
   }
 }

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.ts
@@ -27,6 +27,7 @@ import { FallbackPageComponent } from '../../../../shared/components/fallback-pa
 import { DvgwFallbackPageComponent } from '../../../../shared/components/dvgw-fallback-page/dvgw-fallback-page.component';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { environment } from '../../../../environments/environment';
+import { getFormatOfPruefidentifikator } from '@hochfrequenz/efoli';
 
 @Component({
   selector: 'app-ahb-page',
@@ -220,31 +221,14 @@ export class AhbPageComponent implements OnInit, OnDestroy {
   }
 
   private getEdifactFormat(pruefi: string): string {
-    const mapping: { [key: string]: string } = {
-      '99': 'APERAK',
-      '29': 'COMDIS',
-      '21': 'IFTSTA',
-      '23': 'INSRPT',
-      '31': 'INVOIC',
-      '13': 'MSCONS',
-      '39': 'ORDCHG',
-      '17': 'ORDERS',
-      '19': 'ORDRSP',
-      '27': 'PRICAT',
-      '15': 'QUOTES',
-      '33': 'REMADV',
-      '35': 'REQOTE',
-      '37': 'PARTIN',
-      '11': 'UTILMD',
-      '25': 'UTILTS',
-      '91': 'CONTRL',
-      '92': 'APERAK',
-      '44': 'UTILMD Gas', // UTILMD for GAS since FV2310
-      '55': 'UTILMD Strom', // UTILMD for STROM since FV2310
-    };
-
-    const key = pruefi.substring(0, 2);
-    return mapping[key];
+    try {
+      const format = getFormatOfPruefidentifikator(pruefi);
+      if (format === 'UTILMDG') return 'UTILMD Gas';
+      if (format === 'UTILMDS') return 'UTILMD Strom';
+      return format;
+    } catch {
+      return '';
+    }
   }
 
   private triggerWarmupIfNeeded(): void {

--- a/src/app/shared/utils/pruefi-format.utils.ts
+++ b/src/app/shared/utils/pruefi-format.utils.ts
@@ -1,29 +1,4 @@
-/**
- * Mapping from Prüfidentifikator prefix (first 2 digits) to EDIFACT format.
- * Each Prüfidentifikator starts with a 2-digit prefix that identifies the format.
- */
-const PRUEFI_PREFIX_TO_FORMAT: Record<string, string> = {
-  '11': 'UTILMD',
-  '13': 'MSCONS',
-  '15': 'QUOTES',
-  '17': 'ORDERS',
-  '19': 'ORDRSP',
-  '21': 'IFTSTA',
-  '23': 'INSRPT',
-  '25': 'UTILTS',
-  '27': 'PRICAT',
-  '29': 'COMDIS',
-  '31': 'INVOIC',
-  '33': 'REMADV',
-  '35': 'REQOTE',
-  '37': 'PARTIN',
-  '39': 'ORDCHG',
-  '44': 'UTILMDG',
-  '55': 'UTILMDS',
-  '91': 'CONTRL',
-  '92': 'APERAK',
-  '99': 'APERAK',
-};
+import { EdifactFormat, getFormatOfPruefidentifikator } from '@hochfrequenz/efoli';
 
 /**
  * Get the EDIFACT format for a given Prüfidentifikator.
@@ -31,8 +6,11 @@ const PRUEFI_PREFIX_TO_FORMAT: Record<string, string> = {
  * @returns The EDIFACT format name (e.g., 'UTILMD', 'UTILMDS') or empty string if unknown
  */
 export function getFormatFromPruefi(pruefi: string): string {
-  const prefix = pruefi.substring(0, 2);
-  return PRUEFI_PREFIX_TO_FORMAT[prefix] || '';
+  try {
+    return getFormatOfPruefidentifikator(pruefi);
+  } catch {
+    return '';
+  }
 }
 
 /**
@@ -40,6 +18,5 @@ export function getFormatFromPruefi(pruefi: string): string {
  * Useful for grouping and sorting operations.
  */
 export function getAllFormats(): string[] {
-  const formats = new Set(Object.values(PRUEFI_PREFIX_TO_FORMAT));
-  return Array.from(formats).sort();
+  return Object.values(EdifactFormat).sort();
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded prefix map in `ahb-page.component.ts` (`getEdifactFormat`) with `getFormatOfPruefidentifikator` from efoli — preserves 'UTILMD Gas' / 'UTILMD Strom' display names for UTILMDG/UTILMDS
- Replace hardcoded cutoff dates + label map in `format-version-select.component.ts` with `getCurrentEdifactFormatVersion` and `getEdifactFormatVersionLabel` from efoli
- Replace local `EdifactFormat` re-implementation in `pruefi-format.utils.ts` with `getFormatOfPruefidentifikator` and `EdifactFormat` from efoli

Display behavior is preserved: the same labels are shown, and the current format version is pre-selected as before.

## Test plan
- [ ] `npx tsc --noEmit` — no new errors (pre-existing errors in test-data.ts and environment.docker.ts are unrelated)
- [ ] Verify format version select pre-selects the current format version
- [ ] Verify format label (e.g. 'UTILMD Gas') is still shown correctly on an AHB page

🤖 Generated with [Claude Code](https://claude.com/claude-code)