### PR TITLE
refactor(server): extract transport-agnostic service layer

### DIFF
--- a/docs/plans/2026-07-06-service-layer-decoupling.md
+++ b/docs/plans/2026-07-06-service-layer-decoupling.md
@@ -1,0 +1,226 @@
+# Service Layer Decoupling (prep for MCP server)
+
+## Goal
+
+Decouple the server's business logic from the Express/HTTP transport so the exact
+same logic can be exposed by **both** the existing HTTP REST API and (in a later
+round) an MCP server.
+
+This document covers **Round 1 only: introduce a transport-agnostic service layer.**
+It is a mechanical, behavior-preserving refactor. Adding the MCP server and shared
+Auth0 token validation is explicitly **out of scope** and will be planned separately.
+
+## Current state (assessment)
+
+Layering today:
+
+```
+server.ts            → Express bootstrap, CORS, DB init, serves Angular
+infrastructure/       api.routes.ts (Express Router), database.ts, errors.ts, xlsx-generator
+controller/*          Express adapters: parse req → validate → call repo → write res
+repository/*          business logic + TypeORM queries  (already Express-free ✅)
+entities/*            domain models
+```
+
+**Good:** the `repository/*` layer has zero Express coupling — clean, reusable
+signatures (`AHBRepository.get(pruefi, fv, fileType)`, `searchAhbLines(payload)`,
+`AhbDiffRepository.getDiff(...)`, etc.). Errors (`AppError` hierarchy) already carry
+transport-neutral data (`statusCode`, `errorCode`, `message`); only `httpErrorHandler`
+is Express-specific.
+
+**Gap:** two kinds of non-HTTP logic are trapped in the controllers and would have to
+be duplicated by an MCP layer:
+
+1. **Input validation** — `^\d{5}$` (pruefi) and `^FV\d{4}$` (format version) regexes
+   are copy-pasted across `ahb.ts` (`:18,:25`) and `ahbDiff.ts` (`:18,:24,:30,:49,:55`).
+   `search.ts` has a _separate_ kind of validation (payload shape: page/pageSize/sort/q,
+   `:17-28`) — no pruefi/fv regexes there. All of these are domain rules, not HTTP rules.
+2. **Format resolution** — the `json|xlsx|csv → FileType` mapping in `ahb.ts` is domain
+   logic tangled together with HTTP concerns (Content-Type / Content-Disposition).
+
+## Endpoint triage
+
+| Endpoint                                                 | Logic in controller today                                | Round-1 action                                                   |
+| -------------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------- |
+| `GET /ahb/:fv/:pruefi`                                   | pruefi+fv validation, `format→FileType`, content headers | → `AhbService.getAhb`                                            |
+| `GET /ahb-diff/:pruefi`                                  | pruefi + 2× fv validation                                | → `AhbDiffService.getDiff`                                       |
+| `GET /ahb-diff-summary`                                  | 2× fv validation                                         | → `AhbDiffService.getSummary`                                    |
+| `POST /search/query`                                     | body validation (page/pageSize/sort/q)                   | → `AhbService.searchAhbLines`                                    |
+| `GET /format-versions`                                   | passthrough                                              | → `MetadataService.listFormatVersions`                           |
+| `GET /formate`                                           | passthrough                                              | → `MetadataService.listFormate`                                  |
+| `GET /direction-values`                                  | passthrough                                              | → `MetadataService.listDirections`                               |
+| `GET /datenstand`                                        | passthrough                                              | → `MetadataService.getDatenstand`                                |
+| `GET /pruefidentifikatoren/:fv`                          | passthrough, **no fv validation today**                  | → `MetadataService.listPruefisByFormatVersion` (adds validation) |
+| `GET /health`, `/api/health`                             | Oh-Dear secret, DB probe, `req.header`                   | **leave HTTP-only** — not a service, not an MCP tool             |
+| `GET /version` (`server.ts:40`)                          | env-var echo                                             | **leave HTTP-only** — infra                                      |
+| `GET /health`, `GET /readiness` root (`server.ts:50-51`) | empty liveness probes                                    | **leave HTTP-only** — infra                                      |
+| `/api/**` catch-all 404 (`api.routes.ts:64`)             | not-found                                                | **leave HTTP-only** — routing                                    |
+
+### Notes surfaced during triage (do NOT fix here — flag only)
+
+- **Validation inconsistency:** `/pruefidentifikatoren/:fv` accepts any string while
+  every other endpoint enforces `^FV\d{4}$`. Round 1 makes validation consistent by
+  routing this through the shared validator. This is the one intentional behavior
+  change (previously-accepted malformed values now 400). Called out explicitly so it
+  is not a surprise.
+- **CSV appears broken today:** the controller maps `csv → FileType.CSV` and sets
+  `text/csv`, but `AHBRepository.get` only handles JSON and XLSX and throws
+  `new Error('Unsupported file type')` (→ 500) for CSV. Round 1 preserves this exact
+  behavior. Do not attempt to implement CSV here — track separately.
+
+## Target structure
+
+```
+src/server/
+  service/
+    validation.ts        # assertPruefi(), assertFormatVersion(), parseFileType()
+    ahb.service.ts       # getAhb(pruefi, fv, format), searchAhbLines(payload)
+    ahbDiff.service.ts   # getDiff(...), getSummary(...)
+    metadata.service.ts  # listFormatVersions / listFormate / listDirections /
+                         #   getDatenstand / listPruefisByFormatVersion
+  controller/*           # thin HTTP adapters: parse req → call service → set headers → serialize
+  repository/*           # UNCHANGED
+  infrastructure/*       # UNCHANGED (errors, database, routes, xlsx-generator)
+```
+
+### Design rules (these make Round 2 / MCP nearly free)
+
+1. **Services never import or touch `express` / `Request` / `Response`.** They take
+   primitives, return domain data, and throw `AppError` subclasses on invalid input.
+2. **`AhbService.getAhb` returns `{ fileType: FileType; content: Ahb | Buffer }`.**
+   The service resolves and validates the format; the _controller_ owns Content-Type
+   and Content-Disposition. An MCP tool will later call this requesting JSON and use
+   `content` directly, ignoring the binary path.
+3. **All validation lives in `service/validation.ts`**, throwing the existing
+   `ValidationError`. One definition of "valid pruefi / valid format version",
+   reused by every transport.
+4. **Errors stay in `infrastructure/errors.ts`.** Round 2 will add an `mcpErrorHandler`
+   mirroring `httpErrorHandler`; no service-layer change needed then.
+5. **Services own their repositories** with the same `constructor(repo?)` default-`new`
+   pattern the controllers use today — preserves the existing test-injection style.
+6. **Controllers now default-`new` their _service_** (`this.service = service ?? new AhbService()`)
+   so the zero-arg construction in `api.routes.ts:13-20` (`new AHBController()`) keeps working
+   unchanged. Both `AHBController` and `SearchController` delegate to the same `AhbService`
+   (both wrap `AHBRepository` today).
+
+### Prerequisite exports (do first — several types are currently inline/unexported)
+
+- `AHBRepository.searchAhbLines` payload and result types are **inline anonymous types**
+  (`repository/ahb.ts:24-74`). Extract and `export` them as `SearchPayload` and
+  `SearchResult` from `repository/ahb.ts` so the service can reference them by name.
+- `PruefiWithName` is a **non-exported** interface in `repository/formatVersion.ts:9`.
+  Add `export`.
+- `AhbDiffRepository.getDiff` returns the repo-local `AhbDiffResult` (`repository/ahbDiff.ts:32-41`),
+  **not** the client model `AhbDiff`. Ensure it's exported and used as the service type.
+
+### Import-source hazard
+
+There are two `AhbDiffSummary` and two `AhbDiff`-ish types: the repository ones
+(`repository/ahbDiff.ts`) and ng-openapi-gen client models under
+`src/app/core/api/models`. **Services must import the repository types**, never the
+client models, or the types will silently diverge. (`Ahb` is the exception — the repo
+itself imports `Ahb` from `../../app/core/api/models`, so the service uses that same one.)
+
+### Proposed signatures
+
+```ts
+// service/validation.ts
+export function assertPruefi(value: string): void; // throws ValidationError
+export function assertFormatVersion(value: string): void; // throws ValidationError
+export function parseFileType(format: string): FileType; // throws ValidationError
+
+// service/ahb.service.ts
+class AhbService {
+  constructor(repository?: AHBRepository);
+  getAhb(
+    pruefi: string,
+    formatVersion: string,
+    format: string
+  ): Promise<{ fileType: FileType; content: Ahb | Buffer }>; // Ahb from app/core/api/models
+  searchAhbLines(payload: SearchPayload): Promise<SearchResult>; // types from repository/ahb
+}
+
+// service/ahbDiff.service.ts
+class AhbDiffService {
+  constructor(repository?: AhbDiffRepository);
+  getDiff(pruefi: string, fvNew: string, fvOld: string): Promise<AhbDiffResult>; // repo type
+  getSummary(fvNew: string, fvOld: string): Promise<AhbDiffSummary>; // repo type
+}
+
+// service/metadata.service.ts — thin delegators, validate fv where relevant
+class MetadataService {
+  listFormatVersions(): Promise<string[]>;
+  listFormate(): Promise<string[]>;
+  listDirections(): Promise<DirectionValues>;
+  getDatenstand(): Promise<DatenstandResult>;
+  listPruefisByFormatVersion(fv: string): Promise<PruefiWithName[]>; // now validates fv
+}
+```
+
+Search payload validation currently lives inline in `search.ts` (page/pageSize are
+positive numbers, sort is an array, q is a string). Move these checks into
+`AhbService.searchAhbLines` before delegating to the repository.
+
+## Controller shape after refactor (example: ahb)
+
+```ts
+public async get(req, res, next) {
+  try {
+    const { fileType, content } = await this.service.getAhb(
+      req.params['pruefi'], req.params['formatVersion'],
+      (req.query['format'] as string) || 'json',
+    );
+    res.status(200)
+      .setHeader('Content-Type', CONTENT_TYPE[fileType])
+      .setHeader('Content-Disposition',
+        `attachment; filename=AHB_${req.params['formatVersion']}_${req.params['pruefi']}.${fileType}`);
+    fileType === FileType.JSON ? res.json(content) : res.send(content);
+  } catch (error) { next(error); }
+}
+```
+
+`CONTENT_TYPE` is an HTTP-only lookup that stays in the controller (or an HTTP helper).
+
+## Testing strategy
+
+- **New:** `service/*.spec.ts` — own the validation and orchestration assertions moved
+  out of the controller specs (invalid pruefi/fv → `ValidationError`, format mapping,
+  search body validation, fv-validation now applied to `listPruefisByFormatVersion`).
+- **Updated:** `controller/*.spec.ts` — shrink to "delegates to service and serializes
+  correctly / sets right headers". Mock the service (same jest-mock pattern used today
+  to mock repositories, e.g. `search.spec.ts`). Note this is a real rewrite, not a tweak:
+  `search.spec.ts` currently `jest.mock('../repository/ahb')` and asserts the
+  page/pageSize/sort/q validation cases (`:91-123`) — those validation assertions must be
+  **relocated** to `ahb.service.spec.ts`, and the controller spec re-pointed to mock
+  `AhbService` instead of `AHBRepository`.
+- **Unchanged:** `repository/*.spec.ts`.
+- Full `npm test` must stay green; no net loss of coverage. `npm run server:build`
+  (tsc) and `npm run server:lint` must pass.
+
+## Step-by-step execution
+
+1. Add prerequisite exports: `SearchPayload`/`SearchResult` from `repository/ahb.ts`,
+   `export` on `PruefiWithName` (`repository/formatVersion.ts`), confirm `AhbDiffResult`
+   exported. Then add `service/validation.ts` + `service/validation.spec.ts`.
+2. Add `AhbService` (getAhb + searchAhbLines) + spec. Rewire `ahb.ts` and `search.ts`
+   controllers to delegate (both to `AhbService`); update their specs (relocate search
+   validation cases into the service spec). Run tests.
+3. Add `AhbDiffService` + spec. Rewire `ahbDiff.ts`; update spec. Run tests.
+4. Add `MetadataService` + spec. Rewire `datenstand`, `formatVersion`, `formate`,
+   `richtung` controllers; update specs. Run tests.
+5. Full `npm test`, `npm run server:build`, `npm run server:lint`. Confirm no behavior
+   change except the intentional `listPruefisByFormatVersion` fv-validation tightening.
+
+## Out of scope (later rounds)
+
+- The MCP server itself (transport choice: streamable HTTP on the same Express app vs.
+  separate stdio process) and its tool definitions.
+- **Auth0 for MCP** — the webapp authenticates client-side via `@auth0/auth0-angular`,
+  but the REST API does **not** appear to validate tokens server-side today. Round 2
+  will likely introduce shared JWT/JWKS validation middleware used by both the REST API
+  and the MCP transport. Design TBD.
+- Fixing CSV export.
+
+```
+
+```

--- a/src/server/controller/ahb.spec.ts
+++ b/src/server/controller/ahb.spec.ts
@@ -1,0 +1,91 @@
+import { Request, Response, NextFunction } from 'express';
+import AHBController from './ahb';
+import AhbService from '../service/ahb.service';
+import { FileType } from '../repository/ahb';
+
+jest.mock('../service/ahb.service');
+
+describe('AHBController', () => {
+  let controller: AHBController;
+  let mockService: jest.Mocked<AhbService>;
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockNext: jest.MockedFunction<NextFunction>;
+  let mockJson: jest.Mock;
+  let mockSend: jest.Mock;
+  let mockStatus: jest.Mock;
+  let mockSetHeader: jest.Mock;
+
+  beforeEach(() => {
+    mockJson = jest.fn();
+    mockSend = jest.fn();
+    mockSetHeader = jest.fn().mockReturnThis();
+    mockStatus = jest.fn().mockReturnValue({ setHeader: mockSetHeader });
+
+    mockReq = { params: {}, query: {} };
+    mockRes = { status: mockStatus, setHeader: mockSetHeader, json: mockJson, send: mockSend };
+    mockNext = jest.fn();
+
+    mockService = { getAhb: jest.fn() } as unknown as jest.Mocked<AhbService>;
+
+    controller = new AHBController(mockService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('defaults to json and serializes via res.json with the JSON content type', async () => {
+    const ahb = { meta: {}, lines: [] } as never;
+    mockService.getAhb.mockResolvedValue({ fileType: FileType.JSON, content: ahb });
+    mockReq.params = { pruefi: '11001', formatVersion: 'FV2410' };
+
+    await controller.get(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockService.getAhb).toHaveBeenCalledWith('11001', 'FV2410', 'json');
+    expect(mockStatus).toHaveBeenCalledWith(200);
+    expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
+    expect(mockSetHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename=AHB_FV2410_11001.json'
+    );
+    expect(mockJson).toHaveBeenCalledWith(ahb);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('serializes binary formats via res.send with the matching content type and filename', async () => {
+    const buffer = Buffer.from('xlsx');
+    mockService.getAhb.mockResolvedValue({ fileType: FileType.XLSX, content: buffer });
+    mockReq.params = { pruefi: '11001', formatVersion: 'FV2410' };
+    mockReq.query = { format: 'xlsx' };
+
+    await controller.get(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockService.getAhb).toHaveBeenCalledWith('11001', 'FV2410', 'xlsx');
+    expect(mockSetHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    expect(mockSetHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename=AHB_FV2410_11001.xlsx'
+    );
+    expect(mockSend).toHaveBeenCalledWith(buffer);
+    expect(mockJson).not.toHaveBeenCalled();
+  });
+
+  it('forwards service errors to next()', async () => {
+    const error = new Error('boom');
+    mockService.getAhb.mockRejectedValue(error);
+    mockReq.params = { pruefi: '11001', formatVersion: 'FV2410' };
+
+    await controller.get(mockReq as Request, mockRes as Response, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(error);
+    expect(mockStatus).not.toHaveBeenCalled();
+  });
+
+  it('creates its own service instance when none is provided', () => {
+    expect(new AHBController()).toBeInstanceOf(AHBController);
+  });
+});

--- a/src/server/controller/ahb.ts
+++ b/src/server/controller/ahb.ts
@@ -1,11 +1,17 @@
-import AHBRepository, { FileType } from '../repository/ahb';
+import { FileType } from '../repository/ahb';
 import { Request, Response, NextFunction } from 'express';
-import { ValidationError } from '../infrastructure/errors';
+import AhbService from '../service/ahb.service';
+
+const CONTENT_TYPE: Record<FileType, string> = {
+  [FileType.XLSX]: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  [FileType.CSV]: 'text/csv',
+  [FileType.JSON]: 'application/json',
+};
 
 export default class AHBController {
-  private repository: AHBRepository;
-  constructor(repository?: AHBRepository) {
-    this.repository = repository ?? new AHBRepository();
+  private service: AhbService;
+  constructor(service?: AhbService) {
+    this.service = service ?? new AhbService();
   }
 
   public async get(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -14,50 +20,14 @@ export default class AHBController {
       const formatVersion = req.params['formatVersion'];
       const format = (req.query['format'] as string) || 'json';
 
-      // Validate prüfidentifikator format (5 digits)
-      if (!/^\d{5}$/.test(pruefi)) {
-        throw new ValidationError(
-          `Invalid Prüfidentifikator format: ${pruefi}. Expected 5 digits.`
-        );
-      }
-
-      // Validate format version pattern (e.g. FV2310)
-      if (!/^FV\d{4}$/.test(formatVersion)) {
-        throw new ValidationError(
-          `Invalid format version: ${formatVersion}. Expected pattern: FV followed by 4 digits.`
-        );
-      }
-
-      let fileType: FileType;
-      let contentType: string;
-
-      switch (format.toLowerCase()) {
-        case 'xlsx':
-          fileType = FileType.XLSX;
-          contentType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-          break;
-        case 'csv':
-          fileType = FileType.CSV;
-          contentType = 'text/csv';
-          break;
-        case 'json':
-          fileType = FileType.JSON;
-          contentType = 'application/json';
-          break;
-        default:
-          throw new ValidationError(
-            `Invalid format: ${format}. Supported formats are: json, xlsx, csv`
-          );
-      }
-
-      const content = await this.repository.get(pruefi, formatVersion, fileType);
+      const { fileType, content } = await this.service.getAhb(pruefi, formatVersion, format);
 
       res
         .status(200)
-        .setHeader('Content-Type', contentType)
+        .setHeader('Content-Type', CONTENT_TYPE[fileType])
         .setHeader(
           'Content-Disposition',
-          `attachment; filename=AHB_${formatVersion}_${pruefi}.${format}`
+          `attachment; filename=AHB_${formatVersion}_${pruefi}.${fileType}`
         );
 
       if (fileType === FileType.JSON) {

--- a/src/server/controller/ahb.ts
+++ b/src/server/controller/ahb.ts
@@ -27,7 +27,7 @@ export default class AHBController {
         .setHeader('Content-Type', CONTENT_TYPE[fileType])
         .setHeader(
           'Content-Disposition',
-          `attachment; filename=AHB_${formatVersion}_${pruefi}.${fileType}`
+          `attachment; filename=AHB_${formatVersion}_${pruefi}.${format}`
         );
 
       if (fileType === FileType.JSON) {

--- a/src/server/controller/ahbDiff.spec.ts
+++ b/src/server/controller/ahbDiff.spec.ts
@@ -1,14 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
 import AhbDiffController from './ahbDiff';
-import AhbDiffRepository from '../repository/ahbDiff';
-import { ValidationError } from '../infrastructure/errors';
+import AhbDiffService from '../service/ahbDiff.service';
 
-jest.mock('../infrastructure/database');
-jest.mock('../repository/ahbDiff');
+jest.mock('../service/ahbDiff.service');
 
 describe('AhbDiffController', () => {
   let controller: AhbDiffController;
-  let mockRepository: jest.Mocked<AhbDiffRepository>;
+  let mockService: jest.Mocked<AhbDiffService>;
   let mockReq: Partial<Request>;
   let mockRes: Partial<Response>;
   let mockNext: jest.MockedFunction<NextFunction>;
@@ -21,137 +19,49 @@ describe('AhbDiffController', () => {
     mockStatus = jest.fn().mockReturnThis();
     mockSetHeader = jest.fn().mockReturnThis();
 
-    mockReq = {
-      params: {},
-      query: {},
-    };
-    mockRes = {
-      status: mockStatus,
-      json: mockJson,
-      setHeader: mockSetHeader,
-    };
+    mockReq = { params: {}, query: {} };
+    mockRes = { status: mockStatus, json: mockJson, setHeader: mockSetHeader };
     mockNext = jest.fn();
 
-    mockRepository = {
+    mockService = {
       getDiff: jest.fn(),
-    } as unknown as jest.Mocked<AhbDiffRepository>;
+      getSummary: jest.fn(),
+    } as unknown as jest.Mocked<AhbDiffService>;
 
-    controller = new AhbDiffController(mockRepository);
+    controller = new AhbDiffController(mockService);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('input validation', () => {
-    it('should reject invalid pruefi format (not 5 digits)', async () => {
-      mockReq.params = { pruefi: '1234' };
-      mockReq.query = { 'format-version-new': 'FV2504', 'format-version-old': 'FV2410' };
-
-      await controller.get(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-      const error = mockNext.mock.calls[0][0] as unknown as ValidationError;
-      expect(error.name).toBe('ValidationError');
-      expect(error.message).toContain('Invalid Prüfidentifikator format');
-    });
-
-    it('should reject invalid pruefi format (letters)', async () => {
-      mockReq.params = { pruefi: 'abcde' };
-      mockReq.query = { 'format-version-new': 'FV2504', 'format-version-old': 'FV2410' };
-
-      await controller.get(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-      const error = mockNext.mock.calls[0][0] as unknown as ValidationError;
-      expect(error.name).toBe('ValidationError');
-    });
-
-    it('should reject missing format-version-new', async () => {
-      mockReq.params = { pruefi: '11042' };
-      mockReq.query = { 'format-version-old': 'FV2410' };
-
-      await controller.get(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-      const error = mockNext.mock.calls[0][0] as unknown as ValidationError;
-      expect(error.name).toBe('ValidationError');
-      expect(error.message).toContain('format-version-new');
-    });
-
-    it('should reject missing format-version-old', async () => {
-      mockReq.params = { pruefi: '11042' };
-      mockReq.query = { 'format-version-new': 'FV2504' };
-
-      await controller.get(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-      const error = mockNext.mock.calls[0][0] as unknown as ValidationError;
-      expect(error.name).toBe('ValidationError');
-      expect(error.message).toContain('format-version-old');
-    });
-
-    it('should reject invalid format-version-new pattern', async () => {
-      mockReq.params = { pruefi: '11042' };
-      mockReq.query = { 'format-version-new': 'invalid', 'format-version-old': 'FV2410' };
-
-      await controller.get(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-      const error = mockNext.mock.calls[0][0] as unknown as ValidationError;
-      expect(error.name).toBe('ValidationError');
-      expect(error.message).toContain('format-version-new');
-    });
-
-    it('should reject invalid format-version-old pattern', async () => {
-      mockReq.params = { pruefi: '11042' };
-      mockReq.query = { 'format-version-new': 'FV2504', 'format-version-old': '2410' };
-
-      await controller.get(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalled();
-      const error = mockNext.mock.calls[0][0] as unknown as ValidationError;
-      expect(error.name).toBe('ValidationError');
-      expect(error.message).toContain('format-version-old');
-    });
-  });
-
-  describe('successful requests', () => {
-    it('should return diff result with valid parameters', async () => {
+  describe('get', () => {
+    it('delegates to the service and serializes the diff result', async () => {
       const mockResult = {
-        lines: [
-          {
-            diff_status: 'unchanged',
-            id_path: 'path/1',
-            sort_path: '001',
-            changed_columns: [],
-            old: { segmentgroup_key: 'SG1' },
-            new: { segmentgroup_key: 'SG1' },
-          },
-        ],
+        lines: [],
         meta: {
           pruefidentifikator: '11042',
           format_version_new: 'FV2504',
           format_version_old: 'FV2410',
         },
       };
-      mockRepository.getDiff.mockResolvedValue(mockResult);
+      mockService.getDiff.mockResolvedValue(mockResult);
 
       mockReq.params = { pruefi: '11042' };
       mockReq.query = { 'format-version-new': 'FV2504', 'format-version-old': 'FV2410' };
 
       await controller.get(mockReq as Request, mockRes as Response, mockNext);
 
-      expect(mockRepository.getDiff).toHaveBeenCalledWith('11042', 'FV2504', 'FV2410');
+      expect(mockService.getDiff).toHaveBeenCalledWith('11042', 'FV2504', 'FV2410');
       expect(mockStatus).toHaveBeenCalledWith(200);
       expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
       expect(mockJson).toHaveBeenCalledWith(mockResult);
       expect(mockNext).not.toHaveBeenCalled();
     });
 
-    it('should pass repository errors to next middleware', async () => {
-      const error = new Error('Database error');
-      mockRepository.getDiff.mockRejectedValue(error);
+    it('forwards service errors to next()', async () => {
+      const error = new Error('boom');
+      mockService.getDiff.mockRejectedValue(error);
 
       mockReq.params = { pruefi: '11042' };
       mockReq.query = { 'format-version-new': 'FV2504', 'format-version-old': 'FV2410' };
@@ -162,8 +72,34 @@ describe('AhbDiffController', () => {
     });
   });
 
-  it('should create its own repository instance when none is provided', () => {
-    const controllerWithDefaultRepo = new AhbDiffController();
-    expect(controllerWithDefaultRepo).toBeInstanceOf(AhbDiffController);
+  describe('getSummary', () => {
+    it('delegates to the service and serializes the summary', async () => {
+      const summary = { '11042': { added: 1, deleted: 0, modified: 2 } };
+      mockService.getSummary.mockResolvedValue(summary);
+
+      mockReq.query = { 'format-version-new': 'FV2504', 'format-version-old': 'FV2410' };
+
+      await controller.getSummary(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockService.getSummary).toHaveBeenCalledWith('FV2504', 'FV2410');
+      expect(mockStatus).toHaveBeenCalledWith(200);
+      expect(mockJson).toHaveBeenCalledWith(summary);
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('forwards service errors to next()', async () => {
+      const error = new Error('boom');
+      mockService.getSummary.mockRejectedValue(error);
+
+      mockReq.query = { 'format-version-new': 'FV2504', 'format-version-old': 'FV2410' };
+
+      await controller.getSummary(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+
+  it('creates its own service instance when none is provided', () => {
+    expect(new AhbDiffController()).toBeInstanceOf(AhbDiffController);
   });
 });

--- a/src/server/controller/ahbDiff.ts
+++ b/src/server/controller/ahbDiff.ts
@@ -1,12 +1,11 @@
-import AhbDiffRepository, { AhbDiffSummary } from '../repository/ahbDiff';
 import { Request, Response, NextFunction } from 'express';
-import { ValidationError } from '../infrastructure/errors';
+import AhbDiffService from '../service/ahbDiff.service';
 
 export default class AhbDiffController {
-  private repository: AhbDiffRepository;
+  private service: AhbDiffService;
 
-  constructor(repository?: AhbDiffRepository) {
-    this.repository = repository ?? new AhbDiffRepository();
+  constructor(service?: AhbDiffService) {
+    this.service = service ?? new AhbDiffService();
   }
 
   public async get(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -15,25 +14,7 @@ export default class AhbDiffController {
       const formatVersionNew = req.query['format-version-new'] as string;
       const formatVersionOld = req.query['format-version-old'] as string;
 
-      if (!/^\d{5}$/.test(pruefi)) {
-        throw new ValidationError(
-          `Invalid Prüfidentifikator format: ${pruefi}. Expected 5 digits.`
-        );
-      }
-
-      if (!formatVersionNew || !/^FV\d{4}$/.test(formatVersionNew)) {
-        throw new ValidationError(
-          `Invalid format-version-new: ${formatVersionNew}. Expected pattern: FV followed by 4 digits.`
-        );
-      }
-
-      if (!formatVersionOld || !/^FV\d{4}$/.test(formatVersionOld)) {
-        throw new ValidationError(
-          `Invalid format-version-old: ${formatVersionOld}. Expected pattern: FV followed by 4 digits.`
-        );
-      }
-
-      const result = await this.repository.getDiff(pruefi, formatVersionNew, formatVersionOld);
+      const result = await this.service.getDiff(pruefi, formatVersionNew, formatVersionOld);
 
       res.status(200).setHeader('Content-Type', 'application/json').json(result);
     } catch (error) {
@@ -46,22 +27,7 @@ export default class AhbDiffController {
       const formatVersionNew = req.query['format-version-new'] as string;
       const formatVersionOld = req.query['format-version-old'] as string;
 
-      if (!formatVersionNew || !/^FV\d{4}$/.test(formatVersionNew)) {
-        throw new ValidationError(
-          `Invalid format-version-new: ${formatVersionNew}. Expected pattern: FV followed by 4 digits.`
-        );
-      }
-
-      if (!formatVersionOld || !/^FV\d{4}$/.test(formatVersionOld)) {
-        throw new ValidationError(
-          `Invalid format-version-old: ${formatVersionOld}. Expected pattern: FV followed by 4 digits.`
-        );
-      }
-
-      const result: AhbDiffSummary = await this.repository.getSummary(
-        formatVersionNew,
-        formatVersionOld
-      );
+      const result = await this.service.getSummary(formatVersionNew, formatVersionOld);
 
       res.status(200).setHeader('Content-Type', 'application/json').json(result);
     } catch (error) {

--- a/src/server/controller/datenstand.ts
+++ b/src/server/controller/datenstand.ts
@@ -1,15 +1,15 @@
 import { Request, Response } from 'express';
-import DatenstandRepository from '../repository/datenstand';
+import MetadataService from '../service/metadata.service';
 
 export default class DatenstandController {
-  private repository: DatenstandRepository;
+  private service: MetadataService;
 
-  constructor(repository?: DatenstandRepository) {
-    this.repository = repository ?? new DatenstandRepository();
+  constructor(service?: MetadataService) {
+    this.service = service ?? new MetadataService();
   }
 
   public async get(_req: Request, res: Response): Promise<void> {
-    const result = await this.repository.getLatestVeroeffentlichungsdatum();
+    const result = await this.service.getDatenstand();
     res.status(200).setHeader('Content-Type', 'application/json').json(result);
   }
 }

--- a/src/server/controller/formatVersion.ts
+++ b/src/server/controller/formatVersion.ts
@@ -1,20 +1,20 @@
 import { Request, Response } from 'express';
-import FormatVersionRepository from '../repository/formatVersion';
+import MetadataService from '../service/metadata.service';
 
 export default class FormatVersionController {
-  private repository: FormatVersionRepository;
-  constructor(repository?: FormatVersionRepository) {
-    this.repository = repository ?? new FormatVersionRepository();
+  private service: MetadataService;
+  constructor(service?: MetadataService) {
+    this.service = service ?? new MetadataService();
   }
 
   public async list(_req: Request, res: Response): Promise<void> {
-    const formatVersionEntity = await this.repository.list();
+    const formatVersionEntity = await this.service.listFormatVersions();
     res.status(200).setHeader('Content-Type', 'application/json').send(formatVersionEntity);
   }
 
   public async listPruefisByFormatVersion(req: Request, res: Response): Promise<void> {
     const formatVersion = req.params['formatVersion'];
-    const pruefis = await this.repository.listPruefisByFormatVersion(formatVersion);
+    const pruefis = await this.service.listPruefisByFormatVersion(formatVersion);
     res.status(200).setHeader('Content-Type', 'application/json').send(pruefis);
   }
 }

--- a/src/server/controller/formate.spec.ts
+++ b/src/server/controller/formate.spec.ts
@@ -1,13 +1,12 @@
 import { Request, Response } from 'express';
 import FormateController from './formate';
-import FormateRepository from '../repository/formate';
+import MetadataService from '../service/metadata.service';
 
-jest.mock('../infrastructure/database');
-jest.mock('../repository/formate');
+jest.mock('../service/metadata.service');
 
 describe('FormateController', () => {
   let formateController: FormateController;
-  let mockFormateRepository: jest.Mocked<FormateRepository>;
+  let mockService: jest.Mocked<MetadataService>;
   let mockReq: Partial<Request>;
   let mockRes: Partial<Response>;
   let mockSend: jest.Mock;
@@ -26,12 +25,11 @@ describe('FormateController', () => {
       setHeader: mockSetHeader,
     };
 
-    // Create a mock repository
-    mockFormateRepository = {
-      list: jest.fn(),
-    } as jest.Mocked<FormateRepository>;
+    mockService = {
+      listFormate: jest.fn(),
+    } as unknown as jest.Mocked<MetadataService>;
 
-    formateController = new FormateController(mockFormateRepository);
+    formateController = new FormateController(mockService);
   });
 
   afterEach(() => {
@@ -40,43 +38,41 @@ describe('FormateController', () => {
 
   it('should return a list of unique formats', async () => {
     const mockFormats = ['CONTRL', 'MSCONS', 'ORDERS', 'UTILMD'];
-    mockFormateRepository.list.mockResolvedValue(mockFormats);
+    mockService.listFormate.mockResolvedValue(mockFormats);
 
     await formateController.list(mockReq as Request, mockRes as Response);
 
-    expect(mockFormateRepository.list).toHaveBeenCalledTimes(1);
+    expect(mockService.listFormate).toHaveBeenCalledTimes(1);
     expect(mockStatus).toHaveBeenCalledWith(200);
     expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
     expect(mockSend).toHaveBeenCalledWith(mockFormats);
   });
 
   it('should handle empty format list', async () => {
-    const mockFormats: string[] = [];
-    mockFormateRepository.list.mockResolvedValue(mockFormats);
+    mockService.listFormate.mockResolvedValue([]);
 
     await formateController.list(mockReq as Request, mockRes as Response);
 
-    expect(mockFormateRepository.list).toHaveBeenCalledTimes(1);
+    expect(mockService.listFormate).toHaveBeenCalledTimes(1);
     expect(mockStatus).toHaveBeenCalledWith(200);
     expect(mockSetHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
     expect(mockSend).toHaveBeenCalledWith([]);
   });
 
-  it('should handle repository errors', async () => {
+  it('should propagate service errors', async () => {
     const error = new Error('Database connection failed');
-    mockFormateRepository.list.mockRejectedValue(error);
+    mockService.listFormate.mockRejectedValue(error);
 
     await expect(formateController.list(mockReq as Request, mockRes as Response)).rejects.toThrow(
       'Database connection failed'
     );
 
-    expect(mockFormateRepository.list).toHaveBeenCalledTimes(1);
+    expect(mockService.listFormate).toHaveBeenCalledTimes(1);
     expect(mockStatus).not.toHaveBeenCalled();
     expect(mockSend).not.toHaveBeenCalled();
   });
 
-  it('should create its own repository instance when none is provided', () => {
-    const controller = new FormateController();
-    expect(controller).toBeInstanceOf(FormateController);
+  it('should create its own service instance when none is provided', () => {
+    expect(new FormateController()).toBeInstanceOf(FormateController);
   });
 });

--- a/src/server/controller/formate.ts
+++ b/src/server/controller/formate.ts
@@ -1,15 +1,15 @@
 import { Request, Response } from 'express';
-import FormateRepository from '../repository/formate';
+import MetadataService from '../service/metadata.service';
 
 export default class FormateController {
-  private repository: FormateRepository;
+  private service: MetadataService;
 
-  constructor(repository?: FormateRepository) {
-    this.repository = repository ?? new FormateRepository();
+  constructor(service?: MetadataService) {
+    this.service = service ?? new MetadataService();
   }
 
   public async list(_req: Request, res: Response): Promise<void> {
-    const formats = await this.repository.list();
+    const formats = await this.service.listFormate();
     res.status(200).setHeader('Content-Type', 'application/json').send(formats);
   }
 }

--- a/src/server/controller/richtung.ts
+++ b/src/server/controller/richtung.ts
@@ -1,15 +1,15 @@
 import { Request, Response } from 'express';
-import RichtungRepository from '../repository/richtung';
+import MetadataService from '../service/metadata.service';
 
 export default class RichtungController {
-  private repository: RichtungRepository;
+  private service: MetadataService;
 
-  constructor(repository?: RichtungRepository) {
-    this.repository = repository ?? new RichtungRepository();
+  constructor(service?: MetadataService) {
+    this.service = service ?? new MetadataService();
   }
 
   public async list(_req: Request, res: Response): Promise<void> {
-    const richtungValues = await this.repository.getDistinctValues();
+    const richtungValues = await this.service.listDirections();
     res.status(200).setHeader('Content-Type', 'application/json').send(richtungValues);
   }
 }

--- a/src/server/controller/search.spec.ts
+++ b/src/server/controller/search.spec.ts
@@ -1,47 +1,39 @@
 import { Request, Response, NextFunction } from 'express';
 import SearchController from './search';
-import AHBRepository from '../repository/ahb';
+import AhbService from '../service/ahb.service';
 
-// Mock the repository
-jest.mock('../repository/ahb');
-const MockedAHBRepository = AHBRepository as jest.MockedClass<typeof AHBRepository>;
+jest.mock('../service/ahb.service');
 
 describe('SearchController', () => {
   let searchController: SearchController;
-  let mockRepository: jest.Mocked<AHBRepository>;
+  let mockService: jest.Mocked<AhbService>;
   let mockReq: Partial<Request>;
   let mockRes: Partial<Response>;
   let mockNext: NextFunction;
   let mockJson: jest.Mock;
   let mockStatus: jest.Mock;
 
-  beforeEach(() => {
-    mockRepository = {
-      searchAhbLines: jest.fn(),
-    } as unknown as jest.Mocked<AHBRepository>;
+  const searchBody = {
+    page: 1,
+    pageSize: 25,
+    sort: [{ field: 'format_version', direction: 'asc' as const }],
+    q: '',
+    filters: {},
+  };
 
-    MockedAHBRepository.mockImplementation(() => mockRepository);
+  beforeEach(() => {
+    mockService = {
+      searchAhbLines: jest.fn(),
+    } as unknown as jest.Mocked<AhbService>;
 
     mockJson = jest.fn();
     mockStatus = jest.fn().mockReturnThis();
     mockNext = jest.fn();
 
-    mockReq = {
-      body: {
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: '',
-        filters: {},
-      },
-    };
+    mockReq = { body: { ...searchBody } };
+    mockRes = { status: mockStatus, json: mockJson };
 
-    mockRes = {
-      status: mockStatus,
-      json: mockJson,
-    };
-
-    searchController = new SearchController(mockRepository);
+    searchController = new SearchController(mockService);
   });
 
   afterEach(() => {
@@ -49,7 +41,7 @@ describe('SearchController', () => {
   });
 
   describe('query', () => {
-    it('should return search results successfully', async () => {
+    it('delegates the request body to the service and serializes the result', async () => {
       const mockSearchResults = {
         items: [
           {
@@ -57,13 +49,6 @@ describe('SearchController', () => {
             format: 'UTILMD',
             pruefidentifikator: '25007',
             description: 'Test description',
-            segmentgroup_key: 'SG6',
-            segment_code: 'NAD',
-            data_element: 'D_3035',
-            qualifier: 'test',
-            line_ahb_status: 'Muss',
-            line_name: 'Test line',
-            bedingung: 'Test condition',
             direction: 'inbound',
           },
         ],
@@ -72,59 +57,28 @@ describe('SearchController', () => {
         pageSize: 25,
       };
 
-      mockRepository.searchAhbLines.mockResolvedValue(mockSearchResults);
+      mockService.searchAhbLines.mockResolvedValue(mockSearchResults);
 
       await searchController.query(mockReq as Request, mockRes as Response, mockNext);
 
-      expect(mockRepository.searchAhbLines).toHaveBeenCalledWith({
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: '',
-        filters: {},
-      });
+      expect(mockService.searchAhbLines).toHaveBeenCalledWith(searchBody);
       expect(mockStatus).toHaveBeenCalledWith(200);
       expect(mockJson).toHaveBeenCalledWith(mockSearchResults);
       expect(mockNext).not.toHaveBeenCalled();
     });
 
-    it('should handle empty request body', async () => {
-      mockReq.body = {};
+    it('passes an empty object to the service when the body is missing', async () => {
+      mockReq.body = undefined;
+      mockService.searchAhbLines.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 25 });
 
       await searchController.query(mockReq as Request, mockRes as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('page must be a positive integer'),
-        })
-      );
+      expect(mockService.searchAhbLines).toHaveBeenCalledWith({});
     });
 
-    it('should validate required fields', async () => {
-      const testCases = [
-        { page: 'invalid', pageSize: 25, sort: [], q: '' },
-        { page: 1, pageSize: 'invalid', sort: [], q: '' },
-        { page: 1, pageSize: 25, sort: 'invalid', q: '' },
-        { page: 1, pageSize: 25, sort: [], q: 123 },
-        { page: 0, pageSize: 25, sort: [], q: '' },
-        { page: 1, pageSize: 0, sort: [], q: '' },
-      ];
-
-      for (const testCase of testCases) {
-        mockReq.body = testCase;
-        await searchController.query(mockReq as Request, mockRes as Response, mockNext);
-        expect(mockNext).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: expect.any(String),
-          })
-        );
-        (mockNext as jest.Mock).mockClear();
-      }
-    });
-
-    it('should handle repository errors', async () => {
+    it('forwards service errors to next()', async () => {
       const error = new Error('Database error');
-      mockRepository.searchAhbLines.mockRejectedValue(error);
+      mockService.searchAhbLines.mockRejectedValue(error);
 
       await searchController.query(mockReq as Request, mockRes as Response, mockNext);
 
@@ -133,184 +87,8 @@ describe('SearchController', () => {
       expect(mockJson).not.toHaveBeenCalled();
     });
 
-    it('should handle complex search parameters', async () => {
-      const complexRequest = {
-        page: 2,
-        pageSize: 50,
-        sort: [
-          { field: 'format_version', direction: 'asc' },
-          { field: 'pruefidentifikator', direction: 'desc' },
-        ],
-        q: 'test search',
-        filters: {
-          format_version: { eq: 'FV2410' },
-          format: { contains: 'UTIL' },
-          segment_code: { in: ['NAD', 'DTM'] },
-          line_ahb_status: { contains: 'Muss' },
-        },
-      };
-
-      mockReq.body = complexRequest;
-      mockRepository.searchAhbLines.mockResolvedValue({
-        items: [],
-        total: 0,
-        page: 2,
-        pageSize: 50,
-      });
-
-      await searchController.query(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockRepository.searchAhbLines).toHaveBeenCalledWith({
-        page: 2,
-        pageSize: 50,
-        sort: [
-          { field: 'format_version', direction: 'asc' },
-          { field: 'pruefidentifikator', direction: 'desc' },
-        ],
-        q: 'test search',
-        filters: {
-          format_version: { eq: 'FV2410' },
-          format: { contains: 'UTIL' },
-          segment_code: { in: ['NAD', 'DTM'] },
-          line_ahb_status: { contains: 'Muss' },
-        },
-      });
-    });
-
-    it('should handle sender filter', async () => {
-      mockReq.body = {
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: '',
-        filters: {
-          sender: { in: ['LF', 'MSB'] },
-        },
-      };
-
-      mockRepository.searchAhbLines.mockResolvedValue({
-        items: [],
-        total: 0,
-        page: 1,
-        pageSize: 25,
-      });
-
-      await searchController.query(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockRepository.searchAhbLines).toHaveBeenCalledWith({
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: '',
-        filters: {
-          sender: { in: ['LF', 'MSB'] },
-        },
-      });
-      expect(mockStatus).toHaveBeenCalledWith(200);
-    });
-
-    it('should handle empfaenger filter', async () => {
-      mockReq.body = {
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: '',
-        filters: {
-          empfaenger: { in: ['NB', 'ESA'] },
-        },
-      };
-
-      mockRepository.searchAhbLines.mockResolvedValue({
-        items: [],
-        total: 0,
-        page: 1,
-        pageSize: 25,
-      });
-
-      await searchController.query(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockRepository.searchAhbLines).toHaveBeenCalledWith({
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: '',
-        filters: {
-          empfaenger: { in: ['NB', 'ESA'] },
-        },
-      });
-      expect(mockStatus).toHaveBeenCalledWith(200);
-    });
-
-    it('should handle both sender and empfaenger filters', async () => {
-      mockReq.body = {
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: '',
-        filters: {
-          sender: { in: ['LF'] },
-          empfaenger: { in: ['MSB', 'NB'] },
-        },
-      };
-
-      mockRepository.searchAhbLines.mockResolvedValue({
-        items: [],
-        total: 0,
-        page: 1,
-        pageSize: 25,
-      });
-
-      await searchController.query(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockRepository.searchAhbLines).toHaveBeenCalledWith({
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: '',
-        filters: {
-          sender: { in: ['LF'] },
-          empfaenger: { in: ['MSB', 'NB'] },
-        },
-      });
-      expect(mockStatus).toHaveBeenCalledWith(200);
-    });
-
-    it('should handle sender and empfaenger with other filters', async () => {
-      mockReq.body = {
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: 'test',
-        filters: {
-          format_version: { in: ['FV2510'] },
-          sender: { in: ['LF'] },
-          empfaenger: { in: ['MSB'] },
-          segment_code: { contains: 'NAD' },
-        },
-      };
-
-      mockRepository.searchAhbLines.mockResolvedValue({
-        items: [],
-        total: 0,
-        page: 1,
-        pageSize: 25,
-      });
-
-      await searchController.query(mockReq as Request, mockRes as Response, mockNext);
-
-      expect(mockRepository.searchAhbLines).toHaveBeenCalledWith({
-        page: 1,
-        pageSize: 25,
-        sort: [{ field: 'format_version', direction: 'asc' }],
-        q: 'test',
-        filters: {
-          format_version: { in: ['FV2510'] },
-          sender: { in: ['LF'] },
-          empfaenger: { in: ['MSB'] },
-          segment_code: { contains: 'NAD' },
-        },
-      });
-      expect(mockStatus).toHaveBeenCalledWith(200);
+    it('creates its own service instance when none is provided', () => {
+      expect(new SearchController()).toBeInstanceOf(SearchController);
     });
   });
 });

--- a/src/server/controller/search.ts
+++ b/src/server/controller/search.ts
@@ -1,40 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
-import AHBRepository from '../repository/ahb';
-import { ValidationError } from '../infrastructure/errors';
+import AhbService from '../service/ahb.service';
 
 export default class SearchController {
-  private repository: AHBRepository;
+  private service: AhbService;
 
-  constructor(repository?: AHBRepository) {
-    this.repository = repository ?? new AHBRepository();
+  constructor(service?: AhbService) {
+    this.service = service ?? new AhbService();
   }
 
   public async query(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const { page, pageSize, sort, q, filters } = req.body || {};
-
-      // Basic validation aligned with OpenAPI (required fields present)
-      if (typeof page !== 'number' || page < 1) {
-        throw new ValidationError('page must be a positive integer');
-      }
-      if (typeof pageSize !== 'number' || pageSize < 1) {
-        throw new ValidationError('pageSize must be a positive integer');
-      }
-      if (!Array.isArray(sort)) {
-        throw new ValidationError('sort must be an array');
-      }
-      if (typeof q !== 'string') {
-        throw new ValidationError('q must be a string');
-      }
-
-      const result = await this.repository.searchAhbLines({
-        page,
-        pageSize,
-        sort,
-        q,
-        filters,
-      });
-
+      const result = await this.service.searchAhbLines(req.body || {});
       res.status(200).json(result);
     } catch (error) {
       next(error);

--- a/src/server/infrastructure/errors.ts
+++ b/src/server/infrastructure/errors.ts
@@ -9,7 +9,9 @@ export class AppError extends Error {
   ) {
     super(message);
     this.name = this.constructor.name;
-    Object.setPrototypeOf(this, AppError.prototype);
+    // Restore the prototype chain to the actual subclass (not hardcoded AppError),
+    // so `instanceof ValidationError` etc. work. `instanceof AppError` still holds.
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }
 

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -12,6 +12,62 @@ export enum FileType {
   XLSX = 'xlsx',
 }
 
+export type SearchFilterField =
+  | 'format_version'
+  | 'format'
+  | 'pruefidentifikator'
+  | 'description'
+  | 'segmentgroup_key'
+  | 'segment_code'
+  | 'data_element'
+  | 'qualifier'
+  | 'line_ahb_status'
+  | 'line_name'
+  | 'bedingung'
+  | 'sender'
+  | 'empfaenger';
+
+export interface SearchFilterCondition {
+  eq?: string;
+  neq?: string;
+  contains?: string;
+  startsWith?: string;
+  endsWith?: string;
+  in?: string[];
+  isNull?: boolean;
+  isNotNull?: boolean;
+}
+
+export interface SearchPayload {
+  page: number;
+  pageSize: number;
+  sort: { field: string; direction?: 'asc' | 'desc' }[];
+  q: string;
+  filters?: Partial<Record<SearchFilterField, SearchFilterCondition>>;
+}
+
+export interface SearchResultItem {
+  format_version: string;
+  format: string;
+  pruefidentifikator: string;
+  description?: string | null;
+  segmentgroup_key?: string | null;
+  segment_code?: string | null;
+  data_element?: string | null;
+  qualifier?: string | null;
+  line_ahb_status?: string | null;
+  line_name?: string | null;
+  bedingung?: string | null;
+  direction?: string | null;
+}
+
+export interface SearchResult {
+  items: SearchResultItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
 export default class AHBRepository {
   private xlsxGenerator: XlsxGeneratorService;
   private richtungRepository: RichtungRepository;
@@ -21,57 +77,7 @@ export default class AHBRepository {
     this.richtungRepository = new RichtungRepository();
   }
 
-  public async searchAhbLines(payload: {
-    page: number;
-    pageSize: number;
-    sort: { field: string; direction?: 'asc' | 'desc' }[];
-    q: string;
-    filters?: Partial<
-      Record<
-        | 'format_version'
-        | 'format'
-        | 'pruefidentifikator'
-        | 'description'
-        | 'segmentgroup_key'
-        | 'segment_code'
-        | 'data_element'
-        | 'qualifier'
-        | 'line_ahb_status'
-        | 'line_name'
-        | 'bedingung'
-        | 'sender'
-        | 'empfaenger',
-        {
-          eq?: string;
-          neq?: string;
-          contains?: string;
-          startsWith?: string;
-          endsWith?: string;
-          in?: string[];
-          isNull?: boolean;
-          isNotNull?: boolean;
-        }
-      >
-    >;
-  }): Promise<{
-    items: Array<{
-      format_version: string;
-      format: string;
-      pruefidentifikator: string;
-      description?: string | null;
-      segmentgroup_key?: string | null;
-      segment_code?: string | null;
-      data_element?: string | null;
-      qualifier?: string | null;
-      line_ahb_status?: string | null;
-      line_name?: string | null;
-      bedingung?: string | null;
-      direction?: string | null;
-    }>;
-    total: number;
-    page: number;
-    pageSize: number;
-  }> {
+  public async searchAhbLines(payload: SearchPayload): Promise<SearchResult> {
     if (!AppDataSource.isInitialized) {
       await AppDataSource.initialize();
     }

--- a/src/server/repository/formatVersion.ts
+++ b/src/server/repository/formatVersion.ts
@@ -6,7 +6,7 @@ interface FormatVersionsWithPruefis {
   [formatVersion: string]: Set<string>;
 }
 
-interface PruefiWithName {
+export interface PruefiWithName {
   pruefidentifikator: string;
   name: string;
 }

--- a/src/server/service/ahb.service.spec.ts
+++ b/src/server/service/ahb.service.spec.ts
@@ -1,0 +1,110 @@
+import AhbService from './ahb.service';
+import AHBRepository, { FileType } from '../repository/ahb';
+import { ValidationError } from '../infrastructure/errors';
+
+describe('AhbService', () => {
+  let service: AhbService;
+  let mockRepository: jest.Mocked<AHBRepository>;
+
+  beforeEach(() => {
+    mockRepository = {
+      get: jest.fn(),
+      searchAhbLines: jest.fn(),
+    } as unknown as jest.Mocked<AHBRepository>;
+
+    service = new AhbService(mockRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAhb', () => {
+    it('resolves the file type and returns the repository content', async () => {
+      const ahb = { meta: {}, lines: [] } as never;
+      mockRepository.get.mockResolvedValue(ahb);
+
+      const result = await service.getAhb('11001', 'FV2410', 'json');
+
+      expect(mockRepository.get).toHaveBeenCalledWith('11001', 'FV2410', FileType.JSON);
+      expect(result).toEqual({ fileType: FileType.JSON, content: ahb });
+    });
+
+    it('maps xlsx to the XLSX file type', async () => {
+      const buffer = Buffer.from('xlsx');
+      mockRepository.get.mockResolvedValue(buffer);
+
+      const result = await service.getAhb('11001', 'FV2410', 'xlsx');
+
+      expect(mockRepository.get).toHaveBeenCalledWith('11001', 'FV2410', FileType.XLSX);
+      expect(result).toEqual({ fileType: FileType.XLSX, content: buffer });
+    });
+
+    it.each(['1234', 'abcde', ''])('rejects invalid pruefi %p', async invalid => {
+      await expect(service.getAhb(invalid, 'FV2410', 'json')).rejects.toThrow(ValidationError);
+      expect(mockRepository.get).not.toHaveBeenCalled();
+    });
+
+    it.each(['FV241', '2410', 'fv2410'])('rejects invalid format version %p', async invalid => {
+      await expect(service.getAhb('11001', invalid, 'json')).rejects.toThrow(ValidationError);
+      expect(mockRepository.get).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unsupported format', async () => {
+      await expect(service.getAhb('11001', 'FV2410', 'pdf')).rejects.toThrow(ValidationError);
+      expect(mockRepository.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('searchAhbLines', () => {
+    const validPayload = {
+      page: 1,
+      pageSize: 25,
+      sort: [{ field: 'format_version', direction: 'asc' as const }],
+      q: '',
+      filters: {},
+    };
+
+    it('delegates a valid payload to the repository', async () => {
+      const results = { items: [], total: 0, page: 1, pageSize: 25 };
+      mockRepository.searchAhbLines.mockResolvedValue(results);
+
+      await expect(service.searchAhbLines(validPayload)).resolves.toBe(results);
+      expect(mockRepository.searchAhbLines).toHaveBeenCalledWith(validPayload);
+    });
+
+    it.each([
+      [{}, 'page must be a positive integer'],
+      [{ ...validPayload, page: 'x' }, 'page must be a positive integer'],
+      [{ ...validPayload, page: 0 }, 'page must be a positive integer'],
+      [{ ...validPayload, pageSize: 'x' }, 'pageSize must be a positive integer'],
+      [{ ...validPayload, pageSize: 0 }, 'pageSize must be a positive integer'],
+      [{ ...validPayload, sort: 'x' }, 'sort must be an array'],
+      [{ ...validPayload, q: 123 }, 'q must be a string'],
+    ])('rejects invalid payload %#', async (payload, message) => {
+      await expect(service.searchAhbLines(payload as never)).rejects.toThrow(message);
+      expect(mockRepository.searchAhbLines).not.toHaveBeenCalled();
+    });
+
+    it('passes sender/empfaenger filters through unchanged', async () => {
+      const payload = {
+        ...validPayload,
+        filters: { sender: { in: ['LF'] }, empfaenger: { in: ['MSB', 'NB'] } },
+      };
+      mockRepository.searchAhbLines.mockResolvedValue({
+        items: [],
+        total: 0,
+        page: 1,
+        pageSize: 25,
+      });
+
+      await service.searchAhbLines(payload);
+
+      expect(mockRepository.searchAhbLines).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  it('creates its own repository when none is provided', () => {
+    expect(new AhbService()).toBeInstanceOf(AhbService);
+  });
+});

--- a/src/server/service/ahb.service.ts
+++ b/src/server/service/ahb.service.ts
@@ -1,0 +1,60 @@
+import { Ahb } from '../../app/core/api/models';
+import AHBRepository, { FileType, SearchPayload, SearchResult } from '../repository/ahb';
+import { ValidationError } from '../infrastructure/errors';
+import { assertPruefi, assertFormatVersion, parseFileType } from './validation';
+
+/**
+ * Transport-agnostic application logic for AHB retrieval and search.
+ *
+ * Knows nothing about Express/HTTP or MCP: it validates primitive inputs, resolves
+ * the requested file type, delegates to {@link AHBRepository}, and returns domain data
+ * (or throws an {@link AppError} subclass). Each transport adapter is responsible for
+ * serialization and protocol-specific concerns (headers, content types, ...).
+ */
+export default class AhbService {
+  private repository: AHBRepository;
+
+  constructor(repository?: AHBRepository) {
+    this.repository = repository ?? new AHBRepository();
+  }
+
+  /**
+   * Retrieve an AHB for a given Prüfidentifikator and format version.
+   * Returns the resolved {@link FileType} alongside the content so the caller can
+   * choose how to serialize it (JSON body vs. binary download).
+   */
+  public async getAhb(
+    pruefi: string,
+    formatVersion: string,
+    format: string
+  ): Promise<{ fileType: FileType; content: Ahb | Buffer }> {
+    assertPruefi(pruefi);
+    assertFormatVersion(formatVersion);
+
+    const fileType = parseFileType(format);
+    const content = await this.repository.get(pruefi, formatVersion, fileType);
+
+    return { fileType, content };
+  }
+
+  /**
+   * Full-text / filtered search over AHB lines. Validates the payload shape before
+   * delegating to the repository.
+   */
+  public async searchAhbLines(payload: SearchPayload): Promise<SearchResult> {
+    if (typeof payload?.page !== 'number' || payload.page < 1) {
+      throw new ValidationError('page must be a positive integer');
+    }
+    if (typeof payload.pageSize !== 'number' || payload.pageSize < 1) {
+      throw new ValidationError('pageSize must be a positive integer');
+    }
+    if (!Array.isArray(payload.sort)) {
+      throw new ValidationError('sort must be an array');
+    }
+    if (typeof payload.q !== 'string') {
+      throw new ValidationError('q must be a string');
+    }
+
+    return this.repository.searchAhbLines(payload);
+  }
+}

--- a/src/server/service/ahb.service.ts
+++ b/src/server/service/ahb.service.ts
@@ -55,6 +55,9 @@ export default class AhbService {
       throw new ValidationError('q must be a string');
     }
 
-    return this.repository.searchAhbLines(payload);
+    // Whitelist the known fields (as the controller did before) so stray body
+    // keys never reach the repository.
+    const { page, pageSize, sort, q, filters } = payload;
+    return this.repository.searchAhbLines({ page, pageSize, sort, q, filters });
   }
 }

--- a/src/server/service/ahbDiff.service.spec.ts
+++ b/src/server/service/ahbDiff.service.spec.ts
@@ -1,0 +1,79 @@
+import AhbDiffService from './ahbDiff.service';
+import AhbDiffRepository from '../repository/ahbDiff';
+import { ValidationError } from '../infrastructure/errors';
+
+describe('AhbDiffService', () => {
+  let service: AhbDiffService;
+  let mockRepository: jest.Mocked<AhbDiffRepository>;
+
+  beforeEach(() => {
+    mockRepository = {
+      getDiff: jest.fn(),
+      getSummary: jest.fn(),
+    } as unknown as jest.Mocked<AhbDiffRepository>;
+
+    service = new AhbDiffService(mockRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getDiff', () => {
+    it('delegates valid parameters to the repository', async () => {
+      const result = {
+        lines: [],
+        meta: {
+          pruefidentifikator: '11042',
+          format_version_new: 'FV2504',
+          format_version_old: 'FV2410',
+        },
+      };
+      mockRepository.getDiff.mockResolvedValue(result);
+
+      await expect(service.getDiff('11042', 'FV2504', 'FV2410')).resolves.toBe(result);
+      expect(mockRepository.getDiff).toHaveBeenCalledWith('11042', 'FV2504', 'FV2410');
+    });
+
+    it.each(['1234', 'abcde'])('rejects invalid pruefi %p', async invalid => {
+      await expect(service.getDiff(invalid, 'FV2504', 'FV2410')).rejects.toThrow(
+        'Invalid Prüfidentifikator format'
+      );
+      expect(mockRepository.getDiff).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing/invalid format-version-new with a field-specific message', async () => {
+      await expect(service.getDiff('11042', undefined as never, 'FV2410')).rejects.toThrow(
+        'format-version-new'
+      );
+      expect(mockRepository.getDiff).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing/invalid format-version-old with a field-specific message', async () => {
+      await expect(service.getDiff('11042', 'FV2504', '2410')).rejects.toThrow(
+        'format-version-old'
+      );
+      expect(mockRepository.getDiff).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSummary', () => {
+    it('delegates valid parameters to the repository', async () => {
+      const summary = { '11042': { added: 1, deleted: 0, modified: 2 } };
+      mockRepository.getSummary.mockResolvedValue(summary);
+
+      await expect(service.getSummary('FV2504', 'FV2410')).resolves.toBe(summary);
+      expect(mockRepository.getSummary).toHaveBeenCalledWith('FV2504', 'FV2410');
+    });
+
+    it('rejects invalid format versions with ValidationError', async () => {
+      await expect(service.getSummary('invalid', 'FV2410')).rejects.toThrow(ValidationError);
+      await expect(service.getSummary('FV2504', 'invalid')).rejects.toThrow('format-version-old');
+      expect(mockRepository.getSummary).not.toHaveBeenCalled();
+    });
+  });
+
+  it('creates its own repository when none is provided', () => {
+    expect(new AhbDiffService()).toBeInstanceOf(AhbDiffService);
+  });
+});

--- a/src/server/service/ahbDiff.service.ts
+++ b/src/server/service/ahbDiff.service.ts
@@ -1,0 +1,36 @@
+import AhbDiffRepository, { AhbDiffResult, AhbDiffSummary } from '../repository/ahbDiff';
+import { assertPruefi, assertFormatVersion } from './validation';
+
+/**
+ * Transport-agnostic application logic for AHB version diffs.
+ * Validates inputs and delegates to {@link AhbDiffRepository}; performs no serialization.
+ */
+export default class AhbDiffService {
+  private repository: AhbDiffRepository;
+
+  constructor(repository?: AhbDiffRepository) {
+    this.repository = repository ?? new AhbDiffRepository();
+  }
+
+  public async getDiff(
+    pruefi: string,
+    formatVersionNew: string,
+    formatVersionOld: string
+  ): Promise<AhbDiffResult> {
+    assertPruefi(pruefi);
+    assertFormatVersion(formatVersionNew, 'format-version-new');
+    assertFormatVersion(formatVersionOld, 'format-version-old');
+
+    return this.repository.getDiff(pruefi, formatVersionNew, formatVersionOld);
+  }
+
+  public async getSummary(
+    formatVersionNew: string,
+    formatVersionOld: string
+  ): Promise<AhbDiffSummary> {
+    assertFormatVersion(formatVersionNew, 'format-version-new');
+    assertFormatVersion(formatVersionOld, 'format-version-old');
+
+    return this.repository.getSummary(formatVersionNew, formatVersionOld);
+  }
+}

--- a/src/server/service/metadata.service.spec.ts
+++ b/src/server/service/metadata.service.spec.ts
@@ -1,0 +1,78 @@
+import MetadataService from './metadata.service';
+import DatenstandRepository from '../repository/datenstand';
+import FormatVersionRepository from '../repository/formatVersion';
+import FormateRepository from '../repository/formate';
+import RichtungRepository from '../repository/richtung';
+import { ValidationError } from '../infrastructure/errors';
+
+describe('MetadataService', () => {
+  let service: MetadataService;
+  let datenstand: jest.Mocked<DatenstandRepository>;
+  let formatVersion: jest.Mocked<FormatVersionRepository>;
+  let formate: jest.Mocked<FormateRepository>;
+  let richtung: jest.Mocked<RichtungRepository>;
+
+  beforeEach(() => {
+    datenstand = {
+      getLatestVeroeffentlichungsdatum: jest.fn(),
+    } as unknown as jest.Mocked<DatenstandRepository>;
+    formatVersion = {
+      list: jest.fn(),
+      listPruefisByFormatVersion: jest.fn(),
+    } as unknown as jest.Mocked<FormatVersionRepository>;
+    formate = { list: jest.fn() } as unknown as jest.Mocked<FormateRepository>;
+    richtung = {
+      getDistinctValues: jest.fn(),
+    } as unknown as jest.Mocked<RichtungRepository>;
+
+    service = new MetadataService({ datenstand, formatVersion, formate, richtung });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delegates listFormatVersions', async () => {
+    formatVersion.list.mockResolvedValue(['FV2410', 'FV2504']);
+    await expect(service.listFormatVersions()).resolves.toEqual(['FV2410', 'FV2504']);
+  });
+
+  it('delegates listFormate', async () => {
+    formate.list.mockResolvedValue(['UTILMD']);
+    await expect(service.listFormate()).resolves.toEqual(['UTILMD']);
+  });
+
+  it('delegates listDirections', async () => {
+    const values = { sender: ['LF'], empfaenger: ['MSB'] };
+    richtung.getDistinctValues.mockResolvedValue(values);
+    await expect(service.listDirections()).resolves.toBe(values);
+  });
+
+  it('delegates getDatenstand', async () => {
+    const result = { veroeffentlichungsdatum: '2025-01-01' } as never;
+    datenstand.getLatestVeroeffentlichungsdatum.mockResolvedValue(result);
+    await expect(service.getDatenstand()).resolves.toBe(result);
+  });
+
+  describe('listPruefisByFormatVersion', () => {
+    it('validates the format version before delegating', async () => {
+      formatVersion.listPruefisByFormatVersion.mockResolvedValue([
+        { pruefidentifikator: '11001', name: 'x' },
+      ]);
+
+      await service.listPruefisByFormatVersion('FV2410');
+
+      expect(formatVersion.listPruefisByFormatVersion).toHaveBeenCalledWith('FV2410');
+    });
+
+    // Intentional behavior change: this endpoint previously accepted any string.
+    it('rejects an invalid format version (previously accepted)', async () => {
+      await expect(service.listPruefisByFormatVersion('nonsense')).rejects.toThrow(ValidationError);
+      expect(formatVersion.listPruefisByFormatVersion).not.toHaveBeenCalled();
+    });
+  });
+
+  it('creates its own repositories when none are provided', () => {
+    expect(new MetadataService()).toBeInstanceOf(MetadataService);
+  });
+});

--- a/src/server/service/metadata.service.ts
+++ b/src/server/service/metadata.service.ts
@@ -1,0 +1,50 @@
+import DatenstandRepository, { DatenstandResult } from '../repository/datenstand';
+import FormatVersionRepository, { PruefiWithName } from '../repository/formatVersion';
+import FormateRepository from '../repository/formate';
+import RichtungRepository, { DirectionValues } from '../repository/richtung';
+import { assertFormatVersion } from './validation';
+
+/**
+ * Transport-agnostic application logic for reference/metadata lookups
+ * (format versions, formats, directions, Datenstand). Thin delegators plus input
+ * validation where the input is user-supplied.
+ */
+export default class MetadataService {
+  private datenstandRepository: DatenstandRepository;
+  private formatVersionRepository: FormatVersionRepository;
+  private formateRepository: FormateRepository;
+  private richtungRepository: RichtungRepository;
+
+  constructor(repositories?: {
+    datenstand?: DatenstandRepository;
+    formatVersion?: FormatVersionRepository;
+    formate?: FormateRepository;
+    richtung?: RichtungRepository;
+  }) {
+    this.datenstandRepository = repositories?.datenstand ?? new DatenstandRepository();
+    this.formatVersionRepository = repositories?.formatVersion ?? new FormatVersionRepository();
+    this.formateRepository = repositories?.formate ?? new FormateRepository();
+    this.richtungRepository = repositories?.richtung ?? new RichtungRepository();
+  }
+
+  public listFormatVersions(): Promise<string[]> {
+    return this.formatVersionRepository.list();
+  }
+
+  public listFormate(): Promise<string[]> {
+    return this.formateRepository.list();
+  }
+
+  public listDirections(): Promise<DirectionValues> {
+    return this.richtungRepository.getDistinctValues();
+  }
+
+  public getDatenstand(): Promise<DatenstandResult> {
+    return this.datenstandRepository.getLatestVeroeffentlichungsdatum();
+  }
+
+  public async listPruefisByFormatVersion(formatVersion: string): Promise<PruefiWithName[]> {
+    assertFormatVersion(formatVersion);
+    return this.formatVersionRepository.listPruefisByFormatVersion(formatVersion);
+  }
+}

--- a/src/server/service/validation.spec.ts
+++ b/src/server/service/validation.spec.ts
@@ -1,0 +1,42 @@
+import { assertPruefi, assertFormatVersion, parseFileType } from './validation';
+import { ValidationError } from '../infrastructure/errors';
+import { FileType } from '../repository/ahb';
+
+describe('validation', () => {
+  describe('assertPruefi', () => {
+    it('accepts exactly 5 digits', () => {
+      expect(() => assertPruefi('11001')).not.toThrow();
+    });
+
+    it.each(['1234', '123456', 'abcde', '', '1100a'])('rejects %p', invalid => {
+      expect(() => assertPruefi(invalid)).toThrow(ValidationError);
+    });
+  });
+
+  describe('assertFormatVersion', () => {
+    it('accepts FV followed by 4 digits', () => {
+      expect(() => assertFormatVersion('FV2310')).not.toThrow();
+    });
+
+    it.each(['FV231', 'FV23100', '2310', 'fv2310', 'FVabcd', ''])('rejects %p', invalid => {
+      expect(() => assertFormatVersion(invalid)).toThrow(ValidationError);
+    });
+  });
+
+  describe('parseFileType', () => {
+    it.each([
+      ['json', FileType.JSON],
+      ['JSON', FileType.JSON],
+      ['xlsx', FileType.XLSX],
+      ['XLSX', FileType.XLSX],
+      ['csv', FileType.CSV],
+      ['CSV', FileType.CSV],
+    ])('maps %p to the expected FileType', (input, expected) => {
+      expect(parseFileType(input)).toBe(expected);
+    });
+
+    it.each(['pdf', 'txt', ''])('rejects unsupported format %p', invalid => {
+      expect(() => parseFileType(invalid)).toThrow(ValidationError);
+    });
+  });
+});

--- a/src/server/service/validation.ts
+++ b/src/server/service/validation.ts
@@ -1,0 +1,48 @@
+import { ValidationError } from '../infrastructure/errors';
+import { FileType } from '../repository/ahb';
+
+const PRUEFI_PATTERN = /^\d{5}$/;
+const FORMAT_VERSION_PATTERN = /^FV\d{4}$/;
+
+/**
+ * Assert that a value is a valid Prüfidentifikator (exactly 5 digits).
+ * Transport-agnostic: throws {@link ValidationError} so every adapter (HTTP, MCP, ...)
+ * maps it to the same error contract.
+ */
+export function assertPruefi(value: string): void {
+  if (!PRUEFI_PATTERN.test(value)) {
+    throw new ValidationError(`Invalid Prüfidentifikator format: ${value}. Expected 5 digits.`);
+  }
+}
+
+/**
+ * Assert that a value is a valid EDIFACT format version (e.g. FV2310).
+ * @param fieldName label used in the error message so callers with multiple format
+ *   versions (e.g. diff endpoints) can identify which one was invalid.
+ */
+export function assertFormatVersion(value: string, fieldName = 'format version'): void {
+  if (!FORMAT_VERSION_PATTERN.test(value)) {
+    throw new ValidationError(
+      `Invalid ${fieldName}: ${value}. Expected pattern: FV followed by 4 digits.`
+    );
+  }
+}
+
+/**
+ * Resolve a user-supplied format string to a {@link FileType}.
+ * Throws {@link ValidationError} for unsupported values.
+ */
+export function parseFileType(format: string): FileType {
+  switch (format.toLowerCase()) {
+    case 'xlsx':
+      return FileType.XLSX;
+    case 'csv':
+      return FileType.CSV;
+    case 'json':
+      return FileType.JSON;
+    default:
+      throw new ValidationError(
+        `Invalid format: ${format}. Supported formats are: json, xlsx, csv`
+      );
+  }
+}


### PR DESCRIPTION
## Why

Prep for exposing the same backend features as **both** the HTTP REST API and (later) an **MCP server**. This is **Round 1**: introduce a transport-agnostic service layer between the Express controllers and the repositories, so the business logic has one entry point that any transport can call. Adding the MCP server + shared Auth0 token validation is a separate future round.

Plan: `docs/plans/2026-07-06-service-layer-decoupling.md`.

## What

New `src/server/service/` layer:
- `validation.ts` — shared `assertPruefi` / `assertFormatVersion(value, fieldName?)` / `parseFileType`
- `ahb.service.ts` — `getAhb` (returns `{ fileType, content }`; controller owns HTTP headers), `searchAhbLines`
- `ahbDiff.service.ts` — `getDiff` / `getSummary`
- `metadata.service.ts` — format versions, formate, directions, datenstand, pruefis-by-format-version

Controllers are now thin HTTP adapters (parse req → call service → serialize). `repository/*` and `api.routes.ts` are unchanged. Validation/search test coverage moved into the service specs; controller specs slimmed to delegation.

## Behavior changes (intentional)

- `GET /pruefidentifikatoren/:fv` now validates the format version and returns **400** on malformed input. Previously it accepted any string (inconsistent with every other endpoint).
- Fixed a latent bug in `infrastructure/errors.ts`: the base `AppError` constructor hardcoded `Object.setPrototypeOf(this, AppError.prototype)`, which broke `instanceof ValidationError` for all subclasses. Changed to `new.target.prototype`. `instanceof AppError` still holds, so `httpErrorHandler` is unaffected.

## Out of scope

- The MCP server itself + shared Auth0 validation (next round).
- CSV export remains broken as before (`AHBRepository.get` throws for CSV) — tracked separately.

## Verification

`npm test` (268 pass), `npm run server:build`, `npm run server:lint`, prettier all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)