### PR TITLE
feat(mcp): MCP server over HTTP with Auth0 (Round 2)

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -3,3 +3,8 @@ ENABLE_CORS=true
 OH_DEAR_HEALTH_CHECK_SECRET=my-secret-oh-dear-health-check-secret
 
 DB_7Z_ARCHIVE_PASSWORD=my-secret-db-7z-archive-password
+
+# MCP server authentication (Auth0). Leave unset to run the /mcp endpoint unauthenticated (local dev).
+# MCP_AUTH0_ISSUER_BASE_URL=https://auth.hochfrequenz.de/
+# MCP_AUTH0_AUDIENCE=https://ahb-tabellen.hochfrequenz.de/mcp
+# MCP_RESOURCE=https://ahb-tabellen.hochfrequenz.de/mcp

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Whenever you want to change something in between frontend and backend, start by 
         └── shared/               # global components (header, footer, logo, etc.)
     ├── assets/                   # logo, favicon, etc.
     ├── server/
-        ├── controller/           # contains code to handle incoming http requests concerning AHB and FormatVersionen
-        ├── infrastructure/       # contains code to manage routing of API endpoints and interact with azure blob storage
-        └── repository/           # contains CRUD operations to register AHB/FormatVersionen related routers
+        ├── controller/           # thin HTTP adapters: parse request → call service → serialize response
+        ├── service/              # transport-agnostic business logic (shared by the REST API and the MCP server)
+        ├── mcp/                  # Model Context Protocol server (Streamable HTTP) exposing the services as tools
+        ├── infrastructure/       # API routing, database access, error handling
+        └── repository/           # CRUD / query operations against the SQLite database
     ├── index.html                # entry point for the angular web application
     ├── main.ts                   # bootstraps the angular web application
     ├── server.ts                 # sets up backend server
@@ -143,6 +145,100 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 
 Run `npm run ng-openapi-gen` to generate the OpenAPI specification and related TypeScript interfaces.
 This command will update the API client code based on the OpenAPI specification.
+
+## 🤖 MCP Server
+
+The backend also exposes the same AHB features as a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server, so AI assistants can query the data as tools. It runs over **Streamable HTTP** on the same Express server, mounted at **`/mcp`**, and delegates to the same `src/server/service/` layer as the REST API.
+
+### Available tools
+
+All tools are read-only:
+
+| Tool                             | Description                                                          |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `get_ahb`                        | Retrieve a single AHB (JSON) by format version + Prüfidentifikator   |
+| `search_ahb_lines`               | Full-text / filtered, paginated search across AHB lines              |
+| `get_ahb_diff`                   | Line-level diff of one Prüfidentifikator between two format versions |
+| `get_ahb_diff_summary`           | Per-Prüfidentifikator change counts between two format versions      |
+| `list_format_versions`           | List all EDIFACT format versions (e.g. `FV2410`)                     |
+| `list_formate`                   | List all EDIFACT formats (e.g. `UTILMD`, `MSCONS`)                   |
+| `list_directions`                | List distinct sender / empfaenger direction values                   |
+| `get_datenstand`                 | Latest publication date (Veröffentlichungsdatum) of the data set     |
+| `list_pruefis_by_format_version` | List all Prüfidentifikatoren in a format version                     |
+
+### Endpoints
+
+- `POST /mcp` — MCP Streamable HTTP endpoint (stateless; use `POST`)
+- `GET /.well-known/oauth-protected-resource/mcp` — OAuth Protected Resource Metadata ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)), only when auth is enabled
+
+### Authentication
+
+The MCP endpoint is protected with **Auth0** (OAuth 2.1) when configured, while the REST API stays open. The server acts as an OAuth **resource server**: MCP clients discover the Auth0 authorization server via the metadata endpoint, run the standard OAuth flow (PKCE, dynamic client registration), and send a `Bearer` access token whose audience is the MCP server.
+
+Configure via environment variables (see `.example.env`):
+
+```bash
+MCP_AUTH0_ISSUER_BASE_URL=https://auth.hochfrequenz.de/
+MCP_AUTH0_AUDIENCE=https://ahb-tabellen.hochfrequenz.de/mcp   # the Auth0 API identifier / canonical MCP URL
+# MCP_RESOURCE=...                                            # optional; defaults to MCP_AUTH0_AUDIENCE
+```
+
+If these are not set, the MCP endpoint runs **unauthenticated** (useful for local development).
+
+### Connecting a client
+
+The endpoint URL is `https://ahb-tabellen.hochfrequenz.de/mcp` (production) or `https://ahb-tabellen.stage.hochfrequenz.de/mcp` (stage). When auth is enabled the client will open a browser for the Auth0 login on first connect.
+
+**Claude (Claude Code / Claude Desktop)** — add a remote MCP server:
+
+```bash
+claude mcp add --transport http ahb-tabellen https://ahb-tabellen.hochfrequenz.de/mcp
+```
+
+Or in the Claude Desktop / `claude.ai` connectors UI, add a custom connector with the same URL. (Equivalent `claude_desktop_config.json` / `.mcp.json` entry:)
+
+```jsonc
+{
+  "mcpServers": {
+    "ahb-tabellen": {
+      "type": "http",
+      "url": "https://ahb-tabellen.hochfrequenz.de/mcp",
+    },
+  },
+}
+```
+
+**GitHub Copilot (VS Code)** — add to `.vscode/mcp.json` (or the user `mcp.json`):
+
+```jsonc
+{
+  "servers": {
+    "ahb-tabellen": {
+      "type": "http",
+      "url": "https://ahb-tabellen.hochfrequenz.de/mcp",
+    },
+  },
+}
+```
+
+Then enable the server in the Copilot Chat **Agent mode** tool picker.
+
+**opencode** — add to `opencode.json`:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "ahb-tabellen": {
+      "type": "remote",
+      "url": "https://ahb-tabellen.hochfrequenz.de/mcp",
+      "enabled": true,
+    },
+  },
+}
+```
+
+For local development against a server started with `npm run server:start`, use `http://localhost:3000/mcp`.
 
 ## 🚀 Deployment
 

--- a/docs/plans/2026-07-06-mcp-server-round2.md
+++ b/docs/plans/2026-07-06-mcp-server-round2.md
@@ -1,0 +1,253 @@
+# MCP Server over HTTP with Auth0 (Round 2)
+
+## Goal
+
+Expose the existing backend features as a **remote MCP server over Streamable HTTP**,
+mounted on the same Express app, reusing the transport-agnostic service layer built in
+Round 1 (`src/server/service/`). Protect the MCP endpoint with **Auth0** using standard
+OAuth 2.1 — the MCP server acts as an OAuth 2.1 **resource server**.
+
+Round 1 (service-layer decoupling) is merged in PR #835 / v1.9.0-rc01. This document is
+Round 2.
+
+## Decisions locked in
+
+- **Transport: Streamable HTTP** on the existing Express app (not stdio). Confirmed by
+  the user and required anyway — MCP's OAuth authorization only applies to HTTP
+  transports (stdio uses env credentials).
+- **Auth scope: protect the MCP endpoint only.** The REST API stays unauthenticated for
+  now so the webapp keeps working unchanged. (See "Why REST stays open" below.)
+- **Standards-based, no wheel-reinvention.** Use Auth0 as the authorization server, its
+  official Express resource-server middleware for token validation, and the tenant's
+  existing DCR + metadata endpoints.
+
+## Confirmed facts (verified against the live tenant + spec)
+
+### Auth0 tenant `auth.hochfrequenz.de` already provides everything we need
+
+Probed `https://auth.hochfrequenz.de/.well-known/openid-configuration` and
+`/.well-known/oauth-authorization-server` (RFC 8414 — both served):
+
+| Capability                                  | Value                                                             | Why it matters                                                |
+| ------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------- |
+| `issuer`                                    | `https://auth.hochfrequenz.de/`                                   | token `iss` to validate                                       |
+| `jwks_uri`                                  | `https://auth.hochfrequenz.de/.well-known/jwks.json`              | RS256 signature validation                                    |
+| `registration_endpoint`                     | `https://auth.hochfrequenz.de/oidc/register`                      | **DCR (RFC 7591) is enabled** — MCP clients can self-register |
+| `code_challenge_methods_supported`          | `[S256]`                                                          | PKCE supported (required by MCP)                              |
+| `token_endpoint_auth_methods_supported`     | includes `none`                                                   | public clients (PKCE) supported                               |
+| `grant_types_supported`                     | incl. `authorization_code`, `refresh_token`, `client_credentials` | interactive + M2M callers                                     |
+| `authorization_endpoint` / `token_endpoint` | `/authorize` / `/oauth/token`                                     | standard Auth0                                                |
+
+So the authorization-server side is done — we do not configure discovery, PKCE, or DCR
+ourselves; Auth0 already exposes them.
+
+### MCP authorization spec (2025-06-18) — what WE must implement on the resource server
+
+From the MCP spec (`modelcontextprotocol.io/specification/2025-06-18/basic/authorization`):
+
+1. The MCP server **MUST** implement **RFC 9728 Protected Resource Metadata**. Because the
+   resource is mounted at a path (`/mcp`), RFC 9728 §3.1 uses **path insertion**: the
+   metadata lives at `https://<host>/.well-known/oauth-protected-resource/mcp` (well-known
+   segment inserted between host and path), **not** at the root
+   `/.well-known/oauth-protected-resource`. Clients that probe PRM proactively request the
+   path-suffixed URL — serve that (or both). Body:
+   `{ "resource": "<canonical MCP URI>", "authorization_servers": ["https://auth.hochfrequenz.de/"] }`.
+   Auth0 does **not** serve this for us — it belongs on the resource server. The MCP TS SDK's
+   `mcpAuthMetadataRouter` handles this pathing for us (see "Use the SDK helpers" below).
+2. On unauthenticated/invalid requests the server **MUST** return **401** with a
+   `WWW-Authenticate` header pointing at the resource-metadata URL (RFC 9728 §5.1).
+3. The server **MUST validate the access token audience** — accept only tokens issued
+   specifically for this MCP server (RFC 8707 / RFC 9068). **MUST NOT** pass the client's
+   token through to any downstream API.
+4. Error contract: 401 (missing/invalid token), 403 (insufficient scope), 400
+   (malformed). Tokens go in `Authorization: Bearer <jwt>` on **every** HTTP request;
+   never in the query string.
+
+The client side (PKCE, `resource` indicator, DCR, browser flow) is handled by the MCP
+client (Claude etc.) + Auth0 — not our code.
+
+## Why REST stays open (context)
+
+The Angular app configures `provideAuth0({ domain, clientId })` with **no `audience` and
+no `httpInterceptor`** (`src/app/app.config.ts`), and gates routes via
+`guards/auth.guard.ts`. It therefore **never sends a Bearer token to the REST API** — the
+API is currently unauthenticated and Auth0 only gates loading the SPA. Turning on token
+validation for the shared API would break the webapp until the Angular client is
+reconfigured to request an API-audience token and attach it. That coordinated change is
+deferred; Round 2 protects only `/mcp`.
+
+## Architecture
+
+```
+src/server.ts
+  ├─ GET /.well-known/oauth-protected-resource   → RFC 9728 metadata (public)
+  ├─ /mcp   → [auth middleware] → StreamableHTTPServerTransport → McpServer
+  ├─ /api/* → REST router (unchanged, unauthenticated)
+  └─ static Angular (unchanged)
+
+src/server/mcp/
+  server.ts        # builds McpServer, registers tools, wires Streamable HTTP transport
+  auth.ts          # Auth0 JWT validation middleware + 401 WWW-Authenticate + PRM handler
+  tools/*.ts       # one thin adapter per tool → calls the Round-1 services
+```
+
+- **Reuses the initialized `AppDataSource`** (TypeORM) from the existing process — no
+  second DB init, no second decrypt. This is the main reason to co-host on Express.
+- **Tools are thin adapters over `src/server/service/*`** — zero business-logic
+  duplication. Validation/format resolution already live in the services.
+
+### Express co-hosting hazards (MUST get right — each silently breaks the flow)
+
+These are mechanical gotchas from mounting on the current `src/server.ts`; none are
+optional:
+
+1. **Route ordering vs. the static catch-alls.** `server.ts:59-62` ends with
+   `server.get('*.*', express.static(...))` then `server.get('*', → index.html)`. The
+   pattern `*.*` matches `/.well-known/oauth-protected-resource` (it contains a dot), and
+   the final `*` returns `index.html` (HTTP 200) for anything unmatched. So **the `/mcp`
+   route(s) and the `.well-known` metadata route MUST be registered before line 59** —
+   otherwise discovery and the SSE `GET /mcp` stream return the Angular index page.
+2. **Global `express.json()` (`server.ts:13`) consumes the body.**
+   `StreamableHTTPServerTransport.handleRequest(req, res)` reads the raw POST stream; with
+   a global JSON parser already applied the request hangs. Fix: call
+   `transport.handleRequest(req, res, req.body)` (pass the already-parsed body), or scope
+   `express.json()` to exclude `/mcp`. Prefer passing `req.body`.
+3. **DB init race (pre-existing).** `AppDataSource.initialize()` is fire-and-forget
+   (`server.ts:32-38`, not awaited before `listen`). REST already has this; MCP inherits
+   it. Consider awaiting init (or gating first tool call) so early MCP calls don't hit an
+   uninitialized DB.
+
+## Auth implementation (standards, minimal custom code)
+
+1. **Create an Auth0 API (resource server)** in the tenant with an **Identifier
+   (audience)** set to the **canonical MCP server URI** (e.g.
+   `https://ahb-tabellen.hochfrequenz.de/mcp`, and the stage equivalent). Setting the
+   audience equal to the canonical URI makes the MCP client's RFC 8707 `resource`
+   parameter line up with Auth0's `audience` (see risk below). Define read scopes if we
+   want per-tool authorization later (e.g. `ahb:read`).
+2. **Token validation middleware:** Auth0's official
+   [`express-oauth2-jwt-bearer`](https://github.com/auth0/node-oauth2-jwt-bearer)
+   configured with `issuerBaseURL: 'https://auth.hochfrequenz.de/'` and
+   `audience: '<API identifier>'`. It fetches JWKS, validates signature (RS256), `iss`,
+   `aud`, and `exp`. Applied only to the `/mcp` route.
+3. **Protected Resource Metadata + 401 handling — use the SDK helpers, don't hand-roll.**
+   The MCP TypeScript SDK ships `mcpAuthMetadataRouter` (serves the path-inserted PRM
+   correctly, per §3.1 above) and `requireBearerAuth` (emits the RFC 9728
+   `WWW-Authenticate` 401 with the `resource_metadata` pointer). Adopt these instead of
+   writing the metadata route and 401 header by hand — they get the pathing and header
+   format right for free. `requireBearerAuth` takes a token verifier; back it with the
+   Auth0 JWKS validation (via `express-oauth2-jwt-bearer` or a small `jose`-based
+   verifier) so signature/`iss`/`aud`/`exp` are checked.
+
+That is the entire server-side auth surface: token verifier + SDK auth router/middleware.
+Everything else (login UI, consent, PKCE, refresh, DCR) is Auth0's.
+
+### Audience/resource must be per-environment
+
+One Auth0 API **per environment** (stage + prod), because the canonical URI differs:
+`https://ahb-tabellen.stage.hochfrequenz.de/mcp` vs
+`https://ahb-tabellen.hochfrequenz.de/mcp` (from `environment.stage.ts` /
+`environment.prod.ts`). The `audience` passed to token validation and the `resource`
+value in PRM must both be env-driven config, not a constant.
+
+### CORS (only matters for in-browser MCP clients)
+
+Claude's remote MCP connector calls **server-side**, so CORS is irrelevant for it. If we
+target in-browser MCP clients, `server.ts:14-26` needs `exposedHeaders` including
+`WWW-Authenticate` (so the client can read the PRM pointer on a 401) and `Mcp-Session-Id`
+(if stateful), and the `.well-known` route must be CORS-reachable. Decide which clients we
+support before adding this.
+
+## Tool surface (read-only; 1:1 with the service layer)
+
+| MCP tool                         | Service method                               | Notes                                                            |
+| -------------------------------- | -------------------------------------------- | ---------------------------------------------------------------- |
+| `get_ahb`                        | `AhbService.getAhb`                          | **JSON only** over MCP; xlsx/csv are downloads, not tool results |
+| `search_ahb_lines`               | `AhbService.searchAhbLines`                  | rich filter schema — invest in good zod descriptions             |
+| `get_ahb_diff`                   | `AhbDiffService.getDiff`                     |                                                                  |
+| `get_ahb_diff_summary`           | `AhbDiffService.getSummary`                  |                                                                  |
+| `list_format_versions`           | `MetadataService.listFormatVersions`         |                                                                  |
+| `list_formate`                   | `MetadataService.listFormate`                |                                                                  |
+| `list_directions`                | `MetadataService.listDirections`             |                                                                  |
+| `get_datenstand`                 | `MetadataService.getDatenstand`              |                                                                  |
+| `list_pruefis_by_format_version` | `MetadataService.listPruefisByFormatVersion` |                                                                  |
+
+- All tools are **read-only** → annotate `readOnlyHint: true`.
+- Inputs described with zod schemas; pruefi = 5 digits, format version = `FV\d{4}`.
+- **Error semantics — two distinct channels:**
+  - Service-layer `ValidationError` / `NotFoundError` (bad pruefi, unknown format version,
+    etc.) → return an MCP **tool result with `isError: true`** and a readable message, so
+    the model can see and react to it. These are _not_ transport errors.
+  - Only **auth** failures are transport-level: 401 (missing/invalid token) / 403
+    (insufficient scope), handled by the auth middleware before the tool runs.
+  - The Round-1 `AppError` prototype fix (`errors.ts:14`, `new.target.prototype`) makes
+    `instanceof ValidationError` reliable, so the tool wrapper can branch on error type.
+- **`get_ahb` has no downstream API** — it queries local TypeORM/sqlite — so the MCP spec's
+  "MUST NOT pass the client token downstream" is trivially satisfied; no token forwarding
+  to build.
+
+## Packages
+
+- `@modelcontextprotocol/sdk` — `McpServer` + `StreamableHTTPServerTransport`, **plus its
+  auth helpers `requireBearerAuth` + `mcpAuthMetadataRouter`** (correct PRM pathing and 401
+  headers — don't hand-roll these).
+- `express-oauth2-jwt-bearer` (or a small `jose` verifier) — Auth0 JWKS token validation,
+  wired as the verifier behind `requireBearerAuth`.
+- `zod` — tool input schemas (SDK peer).
+- Express is `^4.21.2` (`package.json`) — compatible with the SDK's Streamable HTTP
+  transport; the Express 4-vs-5 distinction is not a blocker here.
+
+## Risks / things to verify before/at implementation
+
+1. **RFC 8707 `resource` vs Auth0 `audience` (the one real wrinkle — spike this first).**
+   MCP clients send `resource=<canonical URI>`; Auth0 historically keys token issuance on
+   `audience`. Setting the Auth0 API Identifier = canonical MCP URI so the two align is the
+   standard, Auth0-recommended mitigation and is sound. **Concrete failure mode to test
+   for:** if the tenant does _not_ honor the `resource` parameter, Auth0 may issue an
+   opaque userinfo token (no proper `aud`) instead of an RS256 JWT for the API — which then
+   fails `express-oauth2-jwt-bearer` audience validation. Verify end-to-end with a real MCP
+   client (Claude) against stage before calling it done. This is the highest-uncertainty
+   item; spike it in step 1.
+2. **DCR registration policy.** DCR is enabled (open `/oidc/register`). Confirm with the
+   Auth0 admins whether open dynamic registration is acceptable, or whether registration
+   should be gated (initial access token / promoted connections). Confused-deputy
+   guidance in the MCP spec applies.
+3. **Session/transport mode.** Streamable HTTP supports stateful (session id) and
+   stateless modes. Decide based on whether we need server→client streaming; stateless is
+   simpler for a read-only query server behind a load balancer.
+4. **CORS + infra.** `/mcp` and the metadata endpoint must be reachable through whatever
+   terminates TLS (Pulumi/Octopus deployment); add `/mcp` to CORS if browser-based MCP
+   clients are expected. Confirm no proxy strips `Authorization`.
+5. **Health/version excluded.** `/health`, `/version`, `/readiness` stay public and
+   non-MCP.
+6. **Operational hygiene.** (a) Rate-limit the authenticated but potentially expensive
+   `search_ahb_lines` tool. (b) Never log the `Authorization` header / token (scrub in any
+   request logging). (c) Prefer **stateless** Streamable HTTP unless we need server→client
+   streaming — simpler behind a load balancer for a read-only query server; if stateful,
+   `Mcp-Session-Id` handling + sticky sessions become a concern.
+
+## Step-by-step
+
+1. **Spike (unauthenticated):** stand up `McpServer` + Streamable HTTP at `/mcp` reusing
+   `AppDataSource`; register 1–2 tools (`list_format_versions`, `get_ahb`) over the
+   existing services. Register the `/mcp` route **before** the `server.ts:59-62`
+   catch-alls, and pass `req.body` into `transport.handleRequest` (see co-hosting
+   hazards). Validate transport with a real MCP client locally.
+   **Then spike the Auth0 `resource`/`audience` behavior early** (risk #1) — it's the
+   highest-uncertainty piece and shapes the auth step.
+2. **Tools:** implement the remaining 7 tool adapters + zod schemas + error mapping.
+3. **Auth0 API:** create the resource server (audience = canonical MCP URI) in the
+   tenant; define scopes if used.
+4. **Auth middleware:** add `express-oauth2-jwt-bearer` on `/mcp`, the
+   `/.well-known/oauth-protected-resource` endpoint, and the 401 `WWW-Authenticate`
+   response.
+5. **End-to-end:** connect Claude (or another MCP client) to the stage URL; verify the
+   full discovery → DCR → PKCE → token → tool-call flow, and that audience validation
+   rejects wrong-audience tokens. Resolve the RFC 8707/audience wrinkle here.
+6. **Docs + deploy config** (CORS, env, Pulumi).
+
+## Out of scope (later)
+
+- Protecting the REST API with Auth0 + reconfiguring the Angular client to send tokens.
+- Fixing CSV export.
+- Per-tool scope-based authorization (start with "authenticated = allowed").

--- a/docs/plans/2026-07-06-mcp-server-round2.md
+++ b/docs/plans/2026-07-06-mcp-server-round2.md
@@ -246,8 +246,31 @@ support before adding this.
    rejects wrong-audience tokens. Resolve the RFC 8707/audience wrinkle here.
 6. **Docs + deploy config** (CORS, env, Pulumi).
 
+## Verification evidence (stage, v1.9.0-rc02)
+
+The unauthenticated transport + all 9 tools were verified live on stage via two
+independent paths (evidence recorded in the issues):
+
+- **Raw HTTP / JSON-RPC** — [#837](https://github.com/Hochfrequenz/ahb-tabellen/issues/837):
+  `initialize`, `tools/list` (exactly 9 tools, all `readOnlyHint`), every tool, and the
+  validation error path (`isError`, no 500) all pass. `search_ahb_lines` reports 287,865
+  lines total; `get_datenstand` → 29.06.2026.
+- **Native MCP client path** ([StreamableHTTPClientTransport] via Claude Code) —
+  [#838](https://github.com/Hochfrequenz/ahb-tabellen/issues/838): all 9 tools work
+  natively, including a real chained diff analysis (Prüfi 55001, FV2604→FV2610). Confirms
+  Streamable HTTP survives the Azure App Service proxy — the main deployment risk.
+
+This closes the "verify transport on stage" item. Still pending (Phase B): the Auth0
+`resource`→`audience` flow, which needs an authenticated client run (see risk #1).
+
+**Follow-up surfaced during #838:** `get_ahb` (~55 KB) and `get_ahb_diff` (~119 KB)
+exceed a single tool-response token budget, so clients offload the payload to a file.
+Functionally correct, but a future improvement could offer a paginated/summarized mode
+for these two tools; for broad questions `search_ahb_lines` is already the efficient path.
+
 ## Out of scope (later)
 
 - Protecting the REST API with Auth0 + reconfiguring the Angular client to send tokens.
 - Fixing CSV export.
 - Per-tool scope-based authorization (start with "authenticated = allowed").
+- Paginated/summarized output mode for `get_ahb` / `get_ahb_diff` (see follow-up above).

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,12 @@
         "@auth0/auth0-angular": "^2.2.3",
         "@hochfrequenz/efoli": "^0.0.8",
         "@mdi/font": "^7.4.47",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "diff": "^8.0.2",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
+        "express-oauth2-jwt-bearer": "^1.9.1",
         "prettier": "^3.5.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "~7.8.2",
@@ -32,6 +34,7 @@
         "tslib": "^2.8.1",
         "typeorm": "^0.3.24",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+        "zod": "^4.4.3",
         "zone.js": "~0.15.1"
       },
       "devDependencies": {
@@ -3570,6 +3573,17 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -4859,6 +4873,333 @@
       "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
       "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
@@ -7437,7 +7778,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -7454,7 +7794,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -10422,6 +10761,25 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10541,6 +10899,42 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-oauth2-jwt-bearer": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/express-oauth2-jwt-bearer/-/express-oauth2-jwt-bearer-1.9.1.tgz",
+      "integrity": "sha512-B3Q+NQDHgmJkMyaCrM0WKxJ6v148rn9v/zQmsYW2WM3zk8dV5uF9Q6NU+d6dQxTORybAWVkeIcK95kkWhQrE9A==",
+      "dependencies": {
+        "jose": "^4.15.5"
+      },
+      "engines": {
+        "node": "^12.19.0 || ^14.15.0 || ^16.13.0 || ^18.12.0 || ^20.2.0 || ^22.1.0 || ^24.0.0"
+      }
+    },
+    "node_modules/express-oauth2-jwt-bearer/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10567,7 +10961,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -10618,7 +11011,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11392,6 +11784,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.28",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
+      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
@@ -11665,11 +12065,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
-      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
-      "dev": true,
-      "license": "MIT",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -11927,11 +12325,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "engines": {
         "node": ">= 12"
       }
@@ -12143,6 +12539,11 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -13094,6 +13495,14 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13228,8 +13637,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -15905,6 +16318,14 @@
         "@napi-rs/nice": "^1.0.1"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
@@ -16778,7 +17199,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17030,6 +17450,30 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -17535,14 +17979,13 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -17554,13 +17997,12 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -21735,6 +22177,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zone.js": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "ng-openapi-gen": "ng-openapi-gen --input openapi.yml --output ./src/app/core/api --indexFile=true",
     "lint": "ng lint",
     "install-submodules": "git submodule update --init --recursive",
-    "test": "jest ."
+    "test": "jest .",
+    "verify:mcp": "node scripts/verify-mcp.mjs"
   },
   "watch": {
     "server:start": {

--- a/package.json
+++ b/package.json
@@ -48,10 +48,12 @@
     "@auth0/auth0-angular": "^2.2.3",
     "@hochfrequenz/efoli": "^0.0.8",
     "@mdi/font": "^7.4.47",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "diff": "^8.0.2",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
+    "express-oauth2-jwt-bearer": "^1.9.1",
     "prettier": "^3.5.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "~7.8.2",
@@ -59,6 +61,7 @@
     "tslib": "^2.8.1",
     "typeorm": "^0.3.24",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+    "zod": "^4.4.3",
     "zone.js": "~0.15.1"
   },
   "devDependencies": {

--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -12,6 +12,8 @@ config:
     secure: AAABABkZ6JHu21N1Q6+hgJVXWzz7KkywfdZ84phM1XkWy6aTrm5zvSibf6PIxCcUJsJgeqDU3aexWUGI7ZH3nFOEIGtpoyKa
   ahb-tabellen:imageName: ghcr.io/hochfrequenz/ahb-tabellen
   ahb-tabellen:imageTag: v1.4.0-rc02
+  ahb-tabellen:mcpAuth0Audience: https://ahb-tabellen.stage.hochfrequenz.de/mcp
+  ahb-tabellen:mcpAuth0IssuerBaseUrl: https://auth.hochfrequenz.de/
   ahb-tabellen:ohDearHealthCheckSecret:
     secure: AAABAFE/v/fLv99CnNg0sBE42GYr5nMYhNJoa1prN9EgomNzl9D0B3vgse7uW3w6
   ahb-tabellen:websitesContainerStartTimeLimit: "300"

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -38,6 +38,13 @@ assert oh_dear_health_check_secret, "ohDearHealthCheckSecret must be set"
 db_7z_archive_password = config.require_secret("db_7z_archive_password")
 assert db_7z_archive_password, "db_7z_archive_password must be set"
 
+# MCP server Auth0 configuration (optional). Set BOTH to protect the /mcp endpoint with
+# Auth0; leave BOTH unset to run /mcp unauthenticated (the server logs a warning). The
+# issuer is the shared tenant; the audience is the per-environment canonical /mcp URL
+# (the Auth0 API identifier). Setting only one is a misconfiguration the server rejects.
+mcp_auth0_issuer_base_url = config.get("mcpAuth0IssuerBaseUrl")
+mcp_auth0_audience = config.get("mcpAuth0Audience")
+
 # App Service Plan SKU configuration (see https://azure.microsoft.com/pricing/details/app-service/)
 # Common SKUs: B1/B2/B3 (Basic), S1/S2/S3 (Standard), P1v2/P2v2/P3v2 (PremiumV2)
 app_service_plan_sku_name = config.get("appServicePlanSkuName") or "B1"
@@ -79,6 +86,39 @@ app_service_plan = azure_native.web.AppServicePlan(
     ),
 )
 
+# Base application settings for the container.
+app_settings = [
+    azure_native.web.NameValuePairArgs(
+        name="DOCKER_REGISTRY_SERVER_URL", value="https://ghcr.io"
+    ),
+    azure_native.web.NameValuePairArgs(
+        name="DOCKER_REGISTRY_SERVER_USERNAME", value="hf-krechan"
+    ),  # Provide GitHub username
+    azure_native.web.NameValuePairArgs(
+        name="DOCKER_REGISTRY_SERVER_PASSWORD", value=ghcr_token
+    ),  # Provide GitHub token or PAT
+    azure_native.web.NameValuePairArgs(name="PORT", value=str(container_port)),
+    azure_native.web.NameValuePairArgs(
+        name="BEDINGUNGSBAUM_BASE_URL", value=bedingungsbaum_base_url
+    ),
+    azure_native.web.NameValuePairArgs(name="EBD_BASE_URL", value=ebd_base_url),
+    azure_native.web.NameValuePairArgs(name="ENVIRONMENT", value=environment),
+    azure_native.web.NameValuePairArgs(name="WEBSITES_CONTAINER_START_TIME_LIMIT", value=websites_container_start_time_limit),
+    azure_native.web.NameValuePairArgs(name="OH_DEAR_HEALTH_CHECK_SECRET", value=oh_dear_health_check_secret),
+    azure_native.web.NameValuePairArgs(name="DB_7Z_ARCHIVE_PASSWORD", value=db_7z_archive_password),
+]
+
+# Enable MCP authentication only when both values are configured for this stack.
+if mcp_auth0_issuer_base_url and mcp_auth0_audience:
+    app_settings.extend([
+        azure_native.web.NameValuePairArgs(
+            name="MCP_AUTH0_ISSUER_BASE_URL", value=mcp_auth0_issuer_base_url
+        ),
+        azure_native.web.NameValuePairArgs(
+            name="MCP_AUTH0_AUDIENCE", value=mcp_auth0_audience
+        ),
+    ])
+
 # Create a Web App
 web_app = azure_native.web.WebApp(
     "ahb-tabellen",
@@ -86,28 +126,7 @@ web_app = azure_native.web.WebApp(
     location=resource_group.location,
     server_farm_id=app_service_plan.id,
     site_config=azure_native.web.SiteConfigArgs(
-        app_settings=[
-            azure_native.web.NameValuePairArgs(
-                name="DOCKER_REGISTRY_SERVER_URL", value="https://ghcr.io"
-            ),
-            azure_native.web.NameValuePairArgs(
-                name="DOCKER_REGISTRY_SERVER_USERNAME", value="hf-krechan"
-            ),  # Provide GitHub username
-            azure_native.web.NameValuePairArgs(
-                name="DOCKER_REGISTRY_SERVER_PASSWORD", value=ghcr_token
-            ),  # Provide GitHub token or PAT
-            azure_native.web.NameValuePairArgs(name="PORT", value=str(container_port)),
-            azure_native.web.NameValuePairArgs(
-                name="BEDINGUNGSBAUM_BASE_URL", value=bedingungsbaum_base_url
-            ),
-            azure_native.web.NameValuePairArgs(
-                name="EBD_BASE_URL", value=ebd_base_url
-            ),
-            azure_native.web.NameValuePairArgs(name="ENVIRONMENT", value=environment),
-            azure_native.web.NameValuePairArgs(name="WEBSITES_CONTAINER_START_TIME_LIMIT", value=websites_container_start_time_limit),
-            azure_native.web.NameValuePairArgs(name="OH_DEAR_HEALTH_CHECK_SECRET", value=oh_dear_health_check_secret),
-            azure_native.web.NameValuePairArgs(name="DB_7Z_ARCHIVE_PASSWORD", value=db_7z_archive_password),
-        ],
+        app_settings=app_settings,
         linux_fx_version=f"DOCKER|{image_name_with_tag}",
     ),
 )

--- a/scripts/verify-mcp.mjs
+++ b/scripts/verify-mcp.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * verify-mcp — external smoke test for the AHB-Tabellen MCP server over HTTP.
+ *
+ * ┌─ SCOPE ────────────────────────────────────────────────────────────────────┐
+ * │ Verifies ONLY the *unauthenticated* MCP transport + tools:                   │
+ * │   • Streamable HTTP reachability and the JSON-RPC / SSE round-trip through    │
+ * │     the deployed reverse proxy (Azure App Service)                            │
+ * │   • the `initialize` handshake                                                │
+ * │   • `tools/list` returns exactly the expected read-only tool set              │
+ * │   • a few `tools/call` return real data from the live database                │
+ * │   • a domain error surfaces as an `isError` tool result (not a crash)         │
+ * │                                                                               │
+ * │ OUT OF SCOPE — NOT tested here: Auth0 / OAuth.                                 │
+ * │   This script sends NO bearer token. Against an auth-protected endpoint every │
+ * │   call returns 401 and this script will (correctly) fail. Token acquisition   │
+ * │   (DCR + PKCE + interactive login) and the RFC 8707 `resource`→`audience`     │
+ * │   mapping can only be verified with a real MCP client (e.g. a Claude Custom   │
+ * │   Connector) once the Auth0 API is configured — see the Auth0 checklist on    │
+ * │   PR #836. Enabling auth is a deliberate, separate milestone.                 │
+ * └───────────────────────────────────────────────────────────────────────────┘
+ *
+ * Usage:  node scripts/verify-mcp.mjs [url]
+ *         MCP_URL=https://host/mcp node scripts/verify-mcp.mjs
+ * Default target: the stage endpoint. Exit code 0 = all checks passed, 1 = failure.
+ *
+ * No dependencies (Node >= 18 global fetch). Not part of the Jest suite — this hits a
+ * live, deployed server, whereas the Jest specs cover the same behavior in-process.
+ */
+
+const DEFAULT_URL = 'https://ahb-tabellen.stage.hochfrequenz.de/mcp';
+const url = process.argv[2] || process.env.MCP_URL || DEFAULT_URL;
+
+const EXPECTED_TOOLS = [
+  'get_ahb',
+  'search_ahb_lines',
+  'get_ahb_diff',
+  'get_ahb_diff_summary',
+  'list_format_versions',
+  'list_formate',
+  'list_directions',
+  'get_datenstand',
+  'list_pruefis_by_format_version',
+].sort();
+
+let rpcId = 0;
+
+/** Send one JSON-RPC request and return its `result` (throws on transport/RPC error). */
+async function rpc(method, params = {}) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: ++rpcId, method, params }),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} for ${method}${res.status === 401 ? ' (auth is enabled — this script is unauthenticated; see SCOPE)' : ''}`);
+  }
+  const contentType = res.headers.get('content-type') ?? '';
+  let message;
+  if (contentType.includes('application/json')) {
+    message = JSON.parse(text);
+  } else {
+    // Streamable HTTP returns the JSON-RPC response as an SSE `data:` line.
+    const line = text.split('\n').find(l => l.startsWith('data:'));
+    if (!line) throw new Error(`No JSON/SSE payload for ${method}: ${text.slice(0, 200)}`);
+    message = JSON.parse(line.slice('data:'.length).trim());
+  }
+  if (message.error) throw new Error(`JSON-RPC error for ${method}: ${JSON.stringify(message.error)}`);
+  return message.result;
+}
+
+const results = [];
+async function check(name, fn) {
+  try {
+    await fn();
+    results.push({ name, ok: true });
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    results.push({ name, ok: false, err });
+    console.log(`  ✗ ${name}\n      ${err.message}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+/** The text payload of a tool result (tools return JSON-in-text content). */
+function toolText(result) {
+  return result?.content?.[0]?.text ?? '';
+}
+
+async function main() {
+  console.log(`verify-mcp → ${url}\n(unauthenticated transport + tools smoke test — see SCOPE in this file)\n`);
+
+  await check('initialize handshake', async () => {
+    const result = await rpc('initialize', {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'verify-mcp', version: '1.0.0' },
+    });
+    assert(result?.serverInfo?.name === 'ahb-tabellen', `unexpected serverInfo: ${JSON.stringify(result?.serverInfo)}`);
+  });
+
+  await check('tools/list returns the expected read-only tool set', async () => {
+    const result = await rpc('tools/list');
+    const names = (result?.tools ?? []).map(t => t.name).sort();
+    assert(
+      JSON.stringify(names) === JSON.stringify(EXPECTED_TOOLS),
+      `tool set mismatch.\n      expected: ${EXPECTED_TOOLS.join(', ')}\n      got:      ${names.join(', ')}`
+    );
+    for (const tool of result.tools) {
+      assert(tool.annotations?.readOnlyHint === true, `tool ${tool.name} is not annotated readOnlyHint`);
+    }
+  });
+
+  await check('tools/call get_datenstand returns data', async () => {
+    const result = await rpc('tools/call', { name: 'get_datenstand', arguments: {} });
+    assert(!result.isError, `tool reported an error: ${toolText(result)}`);
+    assert(toolText(result).length > 0, 'empty result content');
+  });
+
+  await check('tools/call list_format_versions returns a non-empty array', async () => {
+    const result = await rpc('tools/call', { name: 'list_format_versions', arguments: {} });
+    assert(!result.isError, `tool reported an error: ${toolText(result)}`);
+    const versions = JSON.parse(toolText(result));
+    assert(Array.isArray(versions) && versions.length > 0, `expected a non-empty array, got: ${toolText(result).slice(0, 120)}`);
+  });
+
+  await check('invalid input surfaces as an isError tool result (not a crash)', async () => {
+    const result = await rpc('tools/call', {
+      name: 'get_ahb',
+      arguments: { formatVersion: 'FV2504', pruefi: 'not-a-pruefi' },
+    });
+    assert(result.isError === true, 'expected isError:true for an invalid Prüfidentifikator');
+    assert(/VALIDATION_ERROR/.test(toolText(result)), `expected a validation error message, got: ${toolText(result).slice(0, 120)}`);
+  });
+
+  const failed = results.filter(r => !r.ok).length;
+  console.log(`\n${failed === 0 ? '✓ all' : `✗ ${failed} of ${results.length}`} checks ${failed === 0 ? 'passed' : 'failed'}.`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error(`\nverify-mcp aborted: ${err.message}`);
+  process.exit(1);
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -30,4 +30,9 @@ export const routes: Routes = [
     loadChildren: async () => (await import('./features/search/search.routes')).SEARCH_ROUTES,
     canActivate: [AuthGuard],
   },
+  {
+    path: 'mcp-integration',
+    loadComponent: async () =>
+      (await import('./features/mcp-info/mcp-info.component')).McpInfoComponent,
+  },
 ];

--- a/src/app/features/mcp-info/mcp-info.component.html
+++ b/src/app/features/mcp-info/mcp-info.component.html
@@ -17,6 +17,10 @@
       <h3 class="text-sm md:text-base font-semibold uppercase tracking-wide mt-6 mb-2">
         Was du damit tun kannst
       </h3>
+      <p class="text-sm md:text-base leading-relaxed mb-2">
+        Kurz gesagt: <strong>alles, was auf dieser Website geht, geht auch per MCP</strong> — nur
+        direkt in deinem KI-Assistenten. Zum Beispiel:
+      </p>
       <ul
         class="list-disc list-outside pl-5 space-y-1 text-sm md:text-base marker:text-hf-dunkel-rose">
         <li>einzelne AHBs zu einer Prüfidentifikator abrufen</li>

--- a/src/app/features/mcp-info/mcp-info.component.html
+++ b/src/app/features/mcp-info/mcp-info.component.html
@@ -1,0 +1,67 @@
+<div class="mx-auto max-w-3xl px-4 py-10 text-hf-dunkel-rose">
+  <h1 class="text-2xl font-bold mb-2">AHB-Tabellen in Ihrem KI-Assistenten nutzen</h1>
+  <p class="text-base leading-relaxed mb-6">
+    Die AHB-Tabellen stehen zusätzlich als <strong>MCP-Server</strong> (Model Context Protocol)
+    bereit. Damit können Sie die AHB-Daten direkt in Ihrem KI-Assistenten – zum Beispiel Claude,
+    GitHub Copilot oder opencode – abfragen, ohne diese Website zu öffnen.
+  </p>
+
+  <h2 class="text-lg font-semibold mb-2">Was Sie damit tun können</h2>
+  <ul class="list-disc list-inside space-y-1 mb-6">
+    <li>einzelne AHBs zu einer Prüfidentifikator abrufen</li>
+    <li>über alle AHB-Zeilen hinweg suchen und filtern</li>
+    <li>zwei Formatversionen miteinander vergleichen (Diff und Änderungsübersicht)</li>
+    <li>verfügbare Formatversionen, Formate und Prüfidentifikatoren auflisten</li>
+  </ul>
+  <p class="text-sm mb-6">
+    Der Server ist <strong>schreibgeschützt</strong> – er liest ausschließlich Daten und verändert
+    nichts.
+  </p>
+
+  <h2 class="text-lg font-semibold mb-2">Server-Adresse</h2>
+  <p class="text-base leading-relaxed mb-2">
+    Tragen Sie in Ihrem KI-Tool die folgende Adresse als Remote- bzw. HTTP-MCP-Server ein:
+  </p>
+  <div class="bg-gray-100 rounded px-4 py-3 font-mono text-sm break-all mb-2">{{ mcpUrl }}</div>
+  <p class="text-sm mb-6">
+    Beim ersten Verbinden öffnet sich gegebenenfalls ein Anmeldefenster – melden Sie sich dort mit
+    Ihrem gewohnten Hochfrequenz-Konto an (dasselbe Login wie für diese Website).
+  </p>
+
+  <h2 class="text-lg font-semibold mb-2">Einrichtung in Ihrem KI-Tool</h2>
+  <p class="text-base leading-relaxed mb-3">
+    Die genauen Schritte unterscheiden sich je nach Tool. Folgen Sie der offiziellen Anleitung Ihres
+    KI-Assistenten und tragen Sie dort die oben genannte Server-Adresse ein:
+  </p>
+  <ul class="list-disc list-inside space-y-2 mb-8">
+    <li>
+      <a
+        class="text-hf-dunkel-blau underline hover:no-underline"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://modelcontextprotocol.io/docs/tutorials/use-remote-mcp-server"
+        >Claude (claude.ai &amp; Claude Desktop – „Custom Connectors")</a
+      >
+    </li>
+    <li>
+      <a
+        class="text-hf-dunkel-blau underline hover:no-underline"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
+        >GitHub Copilot in VS Code</a
+      >
+    </li>
+    <li>
+      <a
+        class="text-hf-dunkel-blau underline hover:no-underline"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://opencode.ai/docs/mcp-servers/"
+        >opencode</a
+      >
+    </li>
+  </ul>
+
+  <a routerLink="/" class="text-sm underline hover:no-underline">&larr; Zurück zur Startseite</a>
+</div>

--- a/src/app/features/mcp-info/mcp-info.component.html
+++ b/src/app/features/mcp-info/mcp-info.component.html
@@ -18,18 +18,17 @@
         Was du damit tun kannst
       </h3>
       <p class="text-sm md:text-base leading-relaxed mb-2">
-        Kurz gesagt: <strong>alles, was auf dieser Website geht, geht auch per MCP</strong> — nur
+        Kurz gesagt: <strong>alles, was auf dieser Website geht, geht auch per MCP</strong>, nur eben
         direkt in deinem KI-Assistenten. Zum Beispiel:
       </p>
       <ul
         class="list-disc list-outside pl-5 space-y-1 text-sm md:text-base marker:text-hf-dunkel-rose">
-        <li>einzelne AHBs zu einer Prüfidentifikator abrufen</li>
-        <li>über alle AHB-Zeilen hinweg suchen und filtern</li>
-        <li>zwei Formatversionen vergleichen (Diff und Änderungsübersicht)</li>
-        <li>Formatversionen, Formate und Prüfidentifikatoren auflisten</li>
+        <li>einzelne AHBs mittels Prüfidentifikator abrufen,</li>
+        <li>über alle AHBs hinweg suchen und filtern,</li>
+        <li>zwei Formatversionen eines AHBs vergleichen.</li>
       </ul>
       <p class="text-xs md:text-sm mt-2 opacity-70">
-        Der Server ist <strong>schreibgeschützt</strong> – er liest ausschließlich Daten.
+        Der MCP-Server ist wie diese Website kostenfrei nutzbar. Du musst dich lediglich anmelden.
       </p>
 
       <h3 class="text-sm md:text-base font-semibold uppercase tracking-wide mt-6 mb-2">
@@ -50,8 +49,8 @@
         </button>
       </div>
       <p class="text-xs md:text-sm mt-2 opacity-70">
-        Beim ersten Verbinden öffnet sich gegebenenfalls ein Anmeldefenster – melde dich dort mit
-        deinem gewohnten Hochfrequenz-Konto an (dasselbe Login wie für diese Website).
+        Beim ersten Verbinden öffnet sich gegebenenfalls ein Anmeldefenster. Melde dich dort mit
+        deinem gewohnten Hochfrequenz-Konto an (dasselbe Login wie für diese Website, ggf. lässt du dir erneut einen 6stelligen Code per Email zuschicken).
       </p>
 
       <h3 class="text-sm md:text-base font-semibold uppercase tracking-wide mt-6 mb-2">
@@ -69,7 +68,7 @@
             rel="noopener noreferrer"
             href="https://modelcontextprotocol.io/docs/tutorials/use-remote-mcp-server">
             Claude
-            <span class="opacity-60">(claude.ai &amp; Claude Desktop – „Custom Connectors")</span>
+            <span class="opacity-60">(claude.ai &amp; Claude Desktop - „Custom Connectors")</span>
             <span class="mdi mdi-open-in-new text-base"></span>
           </a>
         </li>

--- a/src/app/features/mcp-info/mcp-info.component.html
+++ b/src/app/features/mcp-info/mcp-info.component.html
@@ -1,67 +1,102 @@
-<div class="mx-auto max-w-3xl px-4 py-10 text-hf-dunkel-rose">
-  <h1 class="text-2xl font-bold mb-2">AHB-Tabellen in Ihrem KI-Assistenten nutzen</h1>
-  <p class="text-base leading-relaxed mb-6">
-    Die AHB-Tabellen stehen zusätzlich als <strong>MCP-Server</strong> (Model Context Protocol)
-    bereit. Damit können Sie die AHB-Daten direkt in Ihrem KI-Assistenten – zum Beispiel Claude,
-    GitHub Copilot oder opencode – abfragen, ohne diese Website zu öffnen.
-  </p>
+<div class="min-h-screen flex flex-col">
+  <section class="bg-hf-grell-rose flex-grow flex justify-center px-4 py-8 md:py-12">
+    <div
+      class="rounded-3xl w-full max-w-2xl bg-hf-pastell-rose p-6 md:p-10 text-hf-weiches-schwarz">
+      <h1 class="text-2xl md:text-3xl pb-3 md:pb-4">MCP-Integration</h1>
+      <h2
+        class="text-base md:text-lg border-b-2 border-hf-grell-rose pb-2 md:pb-3 mb-4 md:mb-6 uppercase">
+        AHB-Tabellen in deinem KI-Assistenten
+      </h2>
 
-  <h2 class="text-lg font-semibold mb-2">Was Sie damit tun können</h2>
-  <ul class="list-disc list-inside space-y-1 mb-6">
-    <li>einzelne AHBs zu einer Prüfidentifikator abrufen</li>
-    <li>über alle AHB-Zeilen hinweg suchen und filtern</li>
-    <li>zwei Formatversionen miteinander vergleichen (Diff und Änderungsübersicht)</li>
-    <li>verfügbare Formatversionen, Formate und Prüfidentifikatoren auflisten</li>
-  </ul>
-  <p class="text-sm mb-6">
-    Der Server ist <strong>schreibgeschützt</strong> – er liest ausschließlich Daten und verändert
-    nichts.
-  </p>
+      <p class="text-sm md:text-base leading-relaxed mb-4">
+        Die AHB-Tabellen stehen zusätzlich als <strong>MCP-Server</strong> (Model Context Protocol)
+        bereit. Damit kannst du die AHB-Daten direkt in deinem KI-Assistenten – etwa Claude, GitHub
+        Copilot oder opencode – abfragen, ohne diese Website zu öffnen.
+      </p>
 
-  <h2 class="text-lg font-semibold mb-2">Server-Adresse</h2>
-  <p class="text-base leading-relaxed mb-2">
-    Tragen Sie in Ihrem KI-Tool die folgende Adresse als Remote- bzw. HTTP-MCP-Server ein:
-  </p>
-  <div class="bg-gray-100 rounded px-4 py-3 font-mono text-sm break-all mb-2">{{ mcpUrl }}</div>
-  <p class="text-sm mb-6">
-    Beim ersten Verbinden öffnet sich gegebenenfalls ein Anmeldefenster – melden Sie sich dort mit
-    Ihrem gewohnten Hochfrequenz-Konto an (dasselbe Login wie für diese Website).
-  </p>
+      <h3 class="text-sm md:text-base font-semibold uppercase tracking-wide mt-6 mb-2">
+        Was du damit tun kannst
+      </h3>
+      <ul
+        class="list-disc list-outside pl-5 space-y-1 text-sm md:text-base marker:text-hf-dunkel-rose">
+        <li>einzelne AHBs zu einer Prüfidentifikator abrufen</li>
+        <li>über alle AHB-Zeilen hinweg suchen und filtern</li>
+        <li>zwei Formatversionen vergleichen (Diff und Änderungsübersicht)</li>
+        <li>Formatversionen, Formate und Prüfidentifikatoren auflisten</li>
+      </ul>
+      <p class="text-xs md:text-sm mt-2 opacity-70">
+        Der Server ist <strong>schreibgeschützt</strong> – er liest ausschließlich Daten.
+      </p>
 
-  <h2 class="text-lg font-semibold mb-2">Einrichtung in Ihrem KI-Tool</h2>
-  <p class="text-base leading-relaxed mb-3">
-    Die genauen Schritte unterscheiden sich je nach Tool. Folgen Sie der offiziellen Anleitung Ihres
-    KI-Assistenten und tragen Sie dort die oben genannte Server-Adresse ein:
-  </p>
-  <ul class="list-disc list-inside space-y-2 mb-8">
-    <li>
-      <a
-        class="text-hf-dunkel-blau underline hover:no-underline"
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://modelcontextprotocol.io/docs/tutorials/use-remote-mcp-server"
-        >Claude (claude.ai &amp; Claude Desktop – „Custom Connectors")</a
-      >
-    </li>
-    <li>
-      <a
-        class="text-hf-dunkel-blau underline hover:no-underline"
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
-        >GitHub Copilot in VS Code</a
-      >
-    </li>
-    <li>
-      <a
-        class="text-hf-dunkel-blau underline hover:no-underline"
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://opencode.ai/docs/mcp-servers/"
-        >opencode</a
-      >
-    </li>
-  </ul>
+      <h3 class="text-sm md:text-base font-semibold uppercase tracking-wide mt-6 mb-2">
+        Server-Adresse
+      </h3>
+      <p class="text-sm md:text-base leading-relaxed mb-2">
+        Trage in deinem KI-Tool die folgende Adresse als Remote- bzw. HTTP-MCP-Server ein:
+      </p>
+      <div
+        class="flex items-center gap-2 rounded-xl bg-hf-weiss-rose border border-hf-grell-rose px-3 py-2 md:px-4 md:py-3">
+        <code class="flex-1 font-mono text-xs md:text-sm break-all">{{ mcpUrl }}</code>
+        <button
+          type="button"
+          (click)="copyUrl()"
+          [attr.aria-label]="copied ? 'Kopiert' : 'Adresse kopieren'"
+          class="flex-none rounded-lg bg-hf-grell-rose hover:bg-hf-dunkel-rose transition-colors px-3 py-1.5 text-xs md:text-sm">
+          {{ copied ? 'Kopiert ✓' : 'Kopieren' }}
+        </button>
+      </div>
+      <p class="text-xs md:text-sm mt-2 opacity-70">
+        Beim ersten Verbinden öffnet sich gegebenenfalls ein Anmeldefenster – melde dich dort mit
+        deinem gewohnten Hochfrequenz-Konto an (dasselbe Login wie für diese Website).
+      </p>
 
-  <a routerLink="/" class="text-sm underline hover:no-underline">&larr; Zurück zur Startseite</a>
+      <h3 class="text-sm md:text-base font-semibold uppercase tracking-wide mt-6 mb-2">
+        Einrichtung in deinem KI-Tool
+      </h3>
+      <p class="text-sm md:text-base leading-relaxed mb-3">
+        Die genauen Schritte unterscheiden sich je nach Tool. Folge der offiziellen Anleitung deines
+        KI-Assistenten und trage dort die oben genannte Server-Adresse ein:
+      </p>
+      <ul class="space-y-2">
+        <li>
+          <a
+            class="inline-flex items-center gap-1 font-medium text-hf-dunkel-blau hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://modelcontextprotocol.io/docs/tutorials/use-remote-mcp-server">
+            Claude
+            <span class="opacity-60">(claude.ai &amp; Claude Desktop – „Custom Connectors")</span>
+            <span class="mdi mdi-open-in-new text-base"></span>
+          </a>
+        </li>
+        <li>
+          <a
+            class="inline-flex items-center gap-1 font-medium text-hf-dunkel-blau hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers">
+            GitHub Copilot in VS Code
+            <span class="mdi mdi-open-in-new text-base"></span>
+          </a>
+        </li>
+        <li>
+          <a
+            class="inline-flex items-center gap-1 font-medium text-hf-dunkel-blau hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://opencode.ai/docs/mcp-servers/">
+            opencode
+            <span class="mdi mdi-open-in-new text-base"></span>
+          </a>
+        </li>
+      </ul>
+
+      <div class="mt-8 pt-4 border-t-2 border-dashed border-hf-grell-rose">
+        <a routerLink="/" class="inline-flex items-center gap-1 text-sm hover:underline">
+          <span class="mdi mdi-arrow-left text-base"></span> Zurück zur Startseite
+        </a>
+      </div>
+    </div>
+  </section>
+  <app-footer />
 </div>

--- a/src/app/features/mcp-info/mcp-info.component.html
+++ b/src/app/features/mcp-info/mcp-info.component.html
@@ -18,8 +18,8 @@
         Was du damit tun kannst
       </h3>
       <p class="text-sm md:text-base leading-relaxed mb-2">
-        Kurz gesagt: <strong>alles, was auf dieser Website geht, geht auch per MCP</strong>, nur eben
-        direkt in deinem KI-Assistenten. Zum Beispiel:
+        Kurz gesagt: <strong>alles, was auf dieser Website geht, geht auch per MCP</strong>, nur
+        eben direkt in deinem KI-Assistenten. Zum Beispiel:
       </p>
       <ul
         class="list-disc list-outside pl-5 space-y-1 text-sm md:text-base marker:text-hf-dunkel-rose">
@@ -50,7 +50,8 @@
       </div>
       <p class="text-xs md:text-sm mt-2 opacity-70">
         Beim ersten Verbinden öffnet sich gegebenenfalls ein Anmeldefenster. Melde dich dort mit
-        deinem gewohnten Hochfrequenz-Konto an (dasselbe Login wie für diese Website, ggf. lässt du dir erneut einen 6stelligen Code per Email zuschicken).
+        deinem gewohnten Hochfrequenz-Konto an (dasselbe Login wie für diese Website, ggf. lässt du
+        dir erneut einen 6stelligen Code per Email zuschicken).
       </p>
 
       <h3 class="text-sm md:text-base font-semibold uppercase tracking-wide mt-6 mb-2">
@@ -60,7 +61,7 @@
         Die genauen Schritte unterscheiden sich je nach Tool. Folge der offiziellen Anleitung deines
         KI-Assistenten und trage dort die oben genannte Server-Adresse ein:
       </p>
-      <ul class="space-y-2">
+      <ul class="space-y-4">
         <li>
           <a
             class="inline-flex items-center gap-1 font-medium text-hf-dunkel-blau hover:underline"
@@ -71,6 +72,22 @@
             <span class="opacity-60">(claude.ai &amp; Claude Desktop - „Custom Connectors")</span>
             <span class="mdi mdi-open-in-new text-base"></span>
           </a>
+        </li>
+        <li>
+          <a
+            class="inline-flex items-center gap-1 font-medium text-hf-dunkel-blau hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://code.claude.com/docs/en/mcp">
+            Claude Code (Terminal)
+            <span class="mdi mdi-open-in-new text-base"></span>
+          </a>
+          <pre
+            class="mt-1 rounded-lg bg-hf-weiss-rose border border-hf-grell-rose px-3 py-2 font-mono text-xs overflow-x-auto"><code>claude mcp add --transport http ahb-tabellen {{ mcpUrl }}</code></pre>
+          <p class="text-xs md:text-sm mt-1 opacity-70">
+            Danach im Claude-Prompt <code class="font-mono">/mcp</code> öffnen und „Authenticate"
+            wählen (öffnet das Login-Fenster).
+          </p>
         </li>
         <li>
           <a
@@ -91,6 +108,11 @@
             opencode
             <span class="mdi mdi-open-in-new text-base"></span>
           </a>
+          <pre
+            class="mt-1 rounded-lg bg-hf-weiss-rose border border-hf-grell-rose px-3 py-2 font-mono text-xs overflow-x-auto"><code>{{ opencodeConfig }}</code></pre>
+          <p class="text-xs md:text-sm mt-1 opacity-70">Danach einmalig anmelden:</p>
+          <pre
+            class="mt-1 rounded-lg bg-hf-weiss-rose border border-hf-grell-rose px-3 py-2 font-mono text-xs overflow-x-auto"><code>opencode mcp auth ahb-tabellen</code></pre>
         </li>
       </ul>
 

--- a/src/app/features/mcp-info/mcp-info.component.spec.ts
+++ b/src/app/features/mcp-info/mcp-info.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { McpInfoComponent } from './mcp-info.component';
 
 describe('McpInfoComponent', () => {
@@ -9,7 +11,8 @@ describe('McpInfoComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [McpInfoComponent],
-      providers: [provideRouter([])],
+      // The embedded <app-footer> pulls in version/datenstand displays that inject HttpClient.
+      providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(McpInfoComponent);

--- a/src/app/features/mcp-info/mcp-info.component.spec.ts
+++ b/src/app/features/mcp-info/mcp-info.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { McpInfoComponent } from './mcp-info.component';
+
+describe('McpInfoComponent', () => {
+  let component: McpInfoComponent;
+  let fixture: ComponentFixture<McpInfoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [McpInfoComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(McpInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('derives the MCP endpoint URL from the current origin', () => {
+    expect(component.mcpUrl).toBe(`${window.location.origin}/mcp`);
+  });
+
+  it('renders the endpoint URL and links to the tool manuals', () => {
+    const html = (fixture.nativeElement as HTMLElement).innerHTML;
+    expect(html).toContain(`${window.location.origin}/mcp`);
+    expect(html).toContain('modelcontextprotocol.io/docs/tutorials/use-remote-mcp-server');
+    expect(html).toContain('code.visualstudio.com/docs/copilot/chat/mcp-servers');
+    expect(html).toContain('opencode.ai/docs/mcp-servers');
+  });
+});

--- a/src/app/features/mcp-info/mcp-info.component.ts
+++ b/src/app/features/mcp-info/mcp-info.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+/**
+ * End-user facing German instructions for connecting the AHB-Tabellen MCP server to an
+ * AI assistant. Intentionally links out to each tool's official manual and only documents
+ * the specifics of *our* server (the endpoint URL + login note).
+ */
+@Component({
+  selector: 'app-mcp-info',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './mcp-info.component.html',
+})
+export class McpInfoComponent {
+  /**
+   * The MCP endpoint lives at `/mcp` on the same origin the app is served from, so this
+   * is correct for whichever environment (stage/prod) the user is currently on.
+   */
+  readonly mcpUrl = `${window.location.origin}/mcp`;
+}

--- a/src/app/features/mcp-info/mcp-info.component.ts
+++ b/src/app/features/mcp-info/mcp-info.component.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { FooterComponent } from '../../shared/components/footer/footer.component';
 
 /**
  * End-user facing German instructions for connecting the AHB-Tabellen MCP server to an
@@ -9,13 +11,31 @@ import { RouterLink } from '@angular/router';
 @Component({
   selector: 'app-mcp-info',
   standalone: true,
-  imports: [RouterLink],
+  imports: [RouterLink, FooterComponent],
   templateUrl: './mcp-info.component.html',
 })
-export class McpInfoComponent {
+export class McpInfoComponent implements OnInit {
   /**
    * The MCP endpoint lives at `/mcp` on the same origin the app is served from, so this
    * is correct for whichever environment (stage/prod) the user is currently on.
    */
   readonly mcpUrl = `${window.location.origin}/mcp`;
+
+  copied = false;
+
+  constructor(private readonly title: Title) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('AHB-Tabellen - MCP-Integration');
+  }
+
+  async copyUrl(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(this.mcpUrl);
+      this.copied = true;
+      setTimeout(() => (this.copied = false), 2000);
+    } catch {
+      // Clipboard API unavailable (e.g. non-secure context) — silently ignore.
+    }
+  }
 }

--- a/src/app/features/mcp-info/mcp-info.component.ts
+++ b/src/app/features/mcp-info/mcp-info.component.ts
@@ -21,6 +21,21 @@ export class McpInfoComponent implements OnInit {
    */
   readonly mcpUrl = `${window.location.origin}/mcp`;
 
+  /**
+   * Ready-to-paste opencode MCP config (see opencode.json). Held as a bound string so the
+   * JSON's literal braces don't collide with Angular's `{{ }}` / ICU template syntax.
+   */
+  readonly opencodeConfig = `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "ahb-tabellen": {
+      "type": "remote",
+      "url": "${window.location.origin}/mcp",
+      "enabled": true
+    }
+  }
+}`;
+
   copied = false;
 
   constructor(private readonly title: Title) {}

--- a/src/app/shared/components/footer/footer.component.html
+++ b/src/app/shared/components/footer/footer.component.html
@@ -55,6 +55,8 @@
             >GitHub</a
           >
           |
+          <a class="ml-1 mr-2 hover:underline" routerLink="/mcp-integration">MCP</a>
+          |
           <a
             class="ml-1 mr-2 hover:underline"
             target="_blank"

--- a/src/app/shared/components/footer/footer.component.spec.ts
+++ b/src/app/shared/components/footer/footer.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FooterComponent } from './footer.component';
 import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 describe('FooterComponent', () => {
   let component: FooterComponent;
@@ -9,7 +10,7 @@ describe('FooterComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [FooterComponent],
-      providers: [provideHttpClient()],
+      providers: [provideHttpClient(), provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(FooterComponent);

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { DatenstandDisplayComponent } from '../datenstand-display/datenstand-display.component';
 import { VersionDisplayComponent } from '../version-display/version-display.component';
 
 @Component({
   selector: 'app-footer',
   standalone: true,
-  imports: [DatenstandDisplayComponent, VersionDisplayComponent],
+  imports: [DatenstandDisplayComponent, VersionDisplayComponent, RouterLink],
   templateUrl: './footer.component.html',
 })
 export class FooterComponent {

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import cors from 'cors';
 import router from './server/infrastructure/api.routes';
 import { httpErrorHandler } from './server/infrastructure/errors';
 import { AppDataSource } from './server/infrastructure/database';
+import { mountMcp } from './server/mcp/http';
 import 'reflect-metadata';
 
 const server = express();
@@ -51,6 +52,10 @@ server.get('/health', (_, res) => res.send());
 server.get('/readiness', (_, res) => res.send());
 
 server.use('/api', router);
+
+// Mount the MCP server (Streamable HTTP) + its OAuth metadata. MUST be registered before
+// the static/catch-all routes below so /mcp and /.well-known are not shadowed by the SPA.
+mountMcp(server);
 
 // Apply error handler middleware
 server.use(httpErrorHandler);

--- a/src/server/mcp/auth.integration.spec.ts
+++ b/src/server/mcp/auth.integration.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ *
+ * Real token-validation integration test for the MCP bearer guard, following Auth0's
+ * resource-server testing guidance: drive the actual `express-oauth2-jwt-bearer` middleware
+ * over HTTP with signed tokens and assert accept/reject on audience, expiry, and signature.
+ *
+ * Uses HS256 with a shared secret so no JWKS server is needed — the audience/issuer/expiry
+ * validation code path is identical to the RS256 path used in production.
+ */
+import crypto from 'crypto';
+import express from 'express';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import { auth } from 'express-oauth2-jwt-bearer';
+import { requireBearer, McpAuthConfig } from './auth';
+
+const SECRET = 'test-shared-secret';
+const ISSUER = 'https://issuer.example.com/';
+const AUDIENCE = 'https://host/mcp';
+
+const config: McpAuthConfig = {
+  issuerBaseURL: ISSUER,
+  audience: AUDIENCE,
+  resource: AUDIENCE,
+};
+
+function base64url(input: string): string {
+  return Buffer.from(input).toString('base64url');
+}
+
+function signHs256(payload: Record<string, unknown>): string {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64url(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const signature = crypto.createHmac('sha256', SECRET).update(data).digest('base64url');
+  return `${data}.${signature}`;
+}
+
+const nowSeconds = (): number => Math.floor(Date.now() / 1000);
+
+describe('MCP bearer auth (real middleware, HTTP)', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(done => {
+    const validate = auth({
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      secret: SECRET,
+      tokenSigningAlg: 'HS256',
+    });
+
+    const app = express();
+    app.get('/mcp', requireBearer(config, validate), (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${port}`;
+      done();
+    });
+  });
+
+  afterAll(done => {
+    server.close(() => done());
+  });
+
+  const call = (token?: string): Promise<Response> =>
+    fetch(`${baseUrl}/mcp`, token ? { headers: { authorization: `Bearer ${token}` } } : undefined);
+
+  it('accepts a valid token', async () => {
+    const token = signHs256({
+      iss: ISSUER,
+      aud: AUDIENCE,
+      sub: 'user-1',
+      iat: nowSeconds(),
+      exp: nowSeconds() + 3600,
+    });
+    const res = await call(token);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it('rejects a request with no token (401 + WWW-Authenticate pointer)', async () => {
+    const res = await call();
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toContain(
+      '/.well-known/oauth-protected-resource/mcp'
+    );
+  });
+
+  it('rejects a token issued for a different audience', async () => {
+    const token = signHs256({
+      iss: ISSUER,
+      aud: 'https://some-other-api/',
+      sub: 'user-1',
+      iat: nowSeconds(),
+      exp: nowSeconds() + 3600,
+    });
+    const res = await call(token);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an expired token', async () => {
+    const token = signHs256({
+      iss: ISSUER,
+      aud: AUDIENCE,
+      sub: 'user-1',
+      iat: nowSeconds() - 7200,
+      exp: nowSeconds() - 3600,
+    });
+    const res = await call(token);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a token with a tampered signature', async () => {
+    const valid = signHs256({
+      iss: ISSUER,
+      aud: AUDIENCE,
+      sub: 'user-1',
+      iat: nowSeconds(),
+      exp: nowSeconds() + 3600,
+    });
+    const tampered = valid.slice(0, -3) + 'xxx';
+    const res = await call(tampered);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/server/mcp/auth.spec.ts
+++ b/src/server/mcp/auth.spec.ts
@@ -1,0 +1,125 @@
+import { Request, Response } from 'express';
+
+// The real express-oauth2-jwt-bearer pulls in jose, whose ESM "browser" build the jsdom
+// test environment cannot parse. We never exercise real JWT validation here (only the
+// missing/malformed-token branch, which does not call auth()), so mock it away.
+jest.mock('express-oauth2-jwt-bearer', () => ({
+  auth: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import {
+  loadMcpAuthConfig,
+  protectedResourceMetadata,
+  resourceMetadataUrl,
+  wwwAuthenticateHeader,
+  requireBearer,
+  McpAuthConfig,
+} from './auth';
+
+const config: McpAuthConfig = {
+  issuerBaseURL: 'https://auth.hochfrequenz.de/',
+  audience: 'https://ahb-tabellen.stage.hochfrequenz.de/mcp',
+  resource: 'https://ahb-tabellen.stage.hochfrequenz.de/mcp',
+};
+
+describe('mcp/auth', () => {
+  describe('loadMcpAuthConfig', () => {
+    it('returns undefined when required env vars are missing (auth disabled)', () => {
+      expect(loadMcpAuthConfig({})).toBeUndefined();
+      expect(loadMcpAuthConfig({ MCP_AUTH0_ISSUER_BASE_URL: 'x' })).toBeUndefined();
+      expect(loadMcpAuthConfig({ MCP_AUTH0_AUDIENCE: 'x' })).toBeUndefined();
+    });
+
+    it('builds config and defaults resource to audience', () => {
+      expect(
+        loadMcpAuthConfig({
+          MCP_AUTH0_ISSUER_BASE_URL: 'https://auth.hochfrequenz.de/',
+          MCP_AUTH0_AUDIENCE: 'https://host/mcp',
+        })
+      ).toEqual({
+        issuerBaseURL: 'https://auth.hochfrequenz.de/',
+        audience: 'https://host/mcp',
+        resource: 'https://host/mcp',
+      });
+    });
+
+    it('honors an explicit MCP_RESOURCE override', () => {
+      expect(
+        loadMcpAuthConfig({
+          MCP_AUTH0_ISSUER_BASE_URL: 'https://auth.hochfrequenz.de/',
+          MCP_AUTH0_AUDIENCE: 'api-id',
+          MCP_RESOURCE: 'https://host/mcp',
+        })?.resource
+      ).toBe('https://host/mcp');
+    });
+  });
+
+  describe('protectedResourceMetadata', () => {
+    it('produces an RFC 9728 document pointing at the authorization server', () => {
+      expect(protectedResourceMetadata(config)).toEqual({
+        resource: config.resource,
+        authorization_servers: ['https://auth.hochfrequenz.de/'],
+        bearer_methods_supported: ['header'],
+      });
+    });
+  });
+
+  describe('resourceMetadataUrl', () => {
+    it('inserts the well-known segment before the resource path (RFC 9728 §3.1)', () => {
+      expect(resourceMetadataUrl(config)).toBe(
+        'https://ahb-tabellen.stage.hochfrequenz.de/.well-known/oauth-protected-resource/mcp'
+      );
+    });
+
+    it('handles a resource with no path', () => {
+      expect(resourceMetadataUrl({ ...config, resource: 'https://host' })).toBe(
+        'https://host/.well-known/oauth-protected-resource'
+      );
+    });
+  });
+
+  describe('wwwAuthenticateHeader', () => {
+    it('includes the resource_metadata pointer', () => {
+      expect(wwwAuthenticateHeader(config)).toBe(
+        'Bearer resource_metadata="https://ahb-tabellen.stage.hochfrequenz.de/.well-known/oauth-protected-resource/mcp"'
+      );
+    });
+
+    it('appends an error code when given', () => {
+      expect(wwwAuthenticateHeader(config, 'invalid_token')).toContain('error="invalid_token"');
+    });
+  });
+
+  describe('requireBearer (missing/malformed token)', () => {
+    let setHeader: jest.Mock;
+    let status: jest.Mock;
+    let json: jest.Mock;
+    let res: Partial<Response>;
+    let next: jest.Mock;
+
+    beforeEach(() => {
+      json = jest.fn();
+      status = jest.fn().mockReturnValue({ json });
+      setHeader = jest.fn();
+      res = { setHeader, status } as unknown as Partial<Response>;
+      next = jest.fn();
+    });
+
+    it('returns 401 with WWW-Authenticate when no Authorization header is present', () => {
+      const req = { headers: {} } as unknown as Request;
+      requireBearer(config)(req, res as Response, next);
+
+      expect(setHeader).toHaveBeenCalledWith('WWW-Authenticate', wwwAuthenticateHeader(config));
+      expect(status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when the Authorization header is not a Bearer token', () => {
+      const req = { headers: { authorization: 'Basic abc' } } as unknown as Request;
+      requireBearer(config)(req, res as Response, next);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/mcp/auth.spec.ts
+++ b/src/server/mcp/auth.spec.ts
@@ -24,10 +24,15 @@ const config: McpAuthConfig = {
 
 describe('mcp/auth', () => {
   describe('loadMcpAuthConfig', () => {
-    it('returns undefined when required env vars are missing (auth disabled)', () => {
+    it('returns undefined when no auth env vars are set (auth intentionally disabled)', () => {
       expect(loadMcpAuthConfig({})).toBeUndefined();
-      expect(loadMcpAuthConfig({ MCP_AUTH0_ISSUER_BASE_URL: 'x' })).toBeUndefined();
-      expect(loadMcpAuthConfig({ MCP_AUTH0_AUDIENCE: 'x' })).toBeUndefined();
+    });
+
+    it('throws on partial configuration (exactly one var set) instead of failing open', () => {
+      expect(() => loadMcpAuthConfig({ MCP_AUTH0_ISSUER_BASE_URL: 'x' })).toThrow(
+        /partially configured/
+      );
+      expect(() => loadMcpAuthConfig({ MCP_AUTH0_AUDIENCE: 'x' })).toThrow(/partially configured/);
     });
 
     it('builds config and defaults resource to audience', () => {

--- a/src/server/mcp/auth.ts
+++ b/src/server/mcp/auth.ts
@@ -1,0 +1,96 @@
+import { RequestHandler } from 'express';
+import { auth } from 'express-oauth2-jwt-bearer';
+
+/** MCP HTTP endpoint path. */
+export const MCP_PATH = '/mcp';
+
+/**
+ * Auth0 resource-server configuration for the MCP endpoint. When absent (env not set),
+ * the MCP endpoint runs unauthenticated (local dev / spike).
+ */
+export interface McpAuthConfig {
+  /** Auth0 issuer base URL, e.g. `https://auth.hochfrequenz.de/`. */
+  issuerBaseURL: string;
+  /** Expected token audience — the Auth0 API identifier (the canonical MCP URI). */
+  audience: string;
+  /** RFC 9728 `resource` value (canonical MCP URI). Defaults to `audience`. */
+  resource: string;
+}
+
+/** Read MCP auth config from the environment; `undefined` disables auth. */
+export function loadMcpAuthConfig(env: NodeJS.ProcessEnv = process.env): McpAuthConfig | undefined {
+  const issuerBaseURL = env['MCP_AUTH0_ISSUER_BASE_URL'];
+  const audience = env['MCP_AUTH0_AUDIENCE'];
+  if (!issuerBaseURL || !audience) {
+    return undefined;
+  }
+  return { issuerBaseURL, audience, resource: env['MCP_RESOURCE'] ?? audience };
+}
+
+/** RFC 9728 Protected Resource Metadata document. */
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  bearer_methods_supported: string[];
+}
+
+export function protectedResourceMetadata(config: McpAuthConfig): ProtectedResourceMetadata {
+  return {
+    resource: config.resource,
+    authorization_servers: [config.issuerBaseURL],
+    bearer_methods_supported: ['header'],
+  };
+}
+
+/**
+ * RFC 9728 §3.1 metadata URL: the well-known segment is inserted between the origin and
+ * the resource's path, e.g. `https://host/mcp` → `https://host/.well-known/oauth-protected-resource/mcp`.
+ */
+export function resourceMetadataUrl(config: McpAuthConfig): string {
+  const url = new URL(config.resource);
+  const path = url.pathname === '/' ? '' : url.pathname;
+  return `${url.origin}/.well-known/oauth-protected-resource${path}`;
+}
+
+/** RFC 9728 §5.1 `WWW-Authenticate` value pointing clients at the resource metadata. */
+export function wwwAuthenticateHeader(config: McpAuthConfig, error?: string): string {
+  const parts = [`Bearer resource_metadata="${resourceMetadataUrl(config)}"`];
+  if (error) {
+    parts.push(`error="${error}"`);
+  }
+  return parts.join(', ');
+}
+
+/**
+ * Bearer-token guard for the MCP endpoint. Missing/malformed `Authorization` headers get
+ * an immediate 401 with the RFC 9728 `WWW-Authenticate` pointer; present tokens are
+ * validated by Auth0's `express-oauth2-jwt-bearer` (signature via JWKS, `iss`, `aud`,
+ * `exp`), which yields 401 on failure — also with the metadata pointer.
+ *
+ * @param validate the token-validation middleware. Defaults to Auth0's `auth()` built
+ *   from `config`; injectable so tests can drive real validation with a local key.
+ */
+export function requireBearer(
+  config: McpAuthConfig,
+  validate: RequestHandler = auth({
+    issuerBaseURL: config.issuerBaseURL,
+    audience: config.audience,
+  })
+): RequestHandler {
+  return (req, res, next) => {
+    const header = req.headers.authorization;
+    if (!header || !/^Bearer\s+\S/i.test(header)) {
+      res.setHeader('WWW-Authenticate', wwwAuthenticateHeader(config));
+      res.status(401).json({ error: 'unauthorized', message: 'Missing bearer token' });
+      return;
+    }
+    validate(req, res, (err?: unknown) => {
+      if (err) {
+        res.setHeader('WWW-Authenticate', wwwAuthenticateHeader(config, 'invalid_token'));
+        res.status(401).json({ error: 'invalid_token', message: 'Invalid or expired token' });
+        return;
+      }
+      next();
+    });
+  };
+}

--- a/src/server/mcp/auth.ts
+++ b/src/server/mcp/auth.ts
@@ -17,12 +17,25 @@ export interface McpAuthConfig {
   resource: string;
 }
 
-/** Read MCP auth config from the environment; `undefined` disables auth. */
+/**
+ * Read MCP auth config from the environment.
+ *
+ * - Both `MCP_AUTH0_ISSUER_BASE_URL` and `MCP_AUTH0_AUDIENCE` set → returns config.
+ * - Neither set → returns `undefined` (auth intentionally disabled, e.g. local dev).
+ * - Exactly one set → throws: a partial config almost certainly means a misconfigured
+ *   deployment, and silently exposing the endpoint unauthenticated would be worse.
+ */
 export function loadMcpAuthConfig(env: NodeJS.ProcessEnv = process.env): McpAuthConfig | undefined {
   const issuerBaseURL = env['MCP_AUTH0_ISSUER_BASE_URL'];
   const audience = env['MCP_AUTH0_AUDIENCE'];
-  if (!issuerBaseURL || !audience) {
+  if (!issuerBaseURL && !audience) {
     return undefined;
+  }
+  if (!issuerBaseURL || !audience) {
+    throw new Error(
+      'MCP auth is partially configured: set BOTH MCP_AUTH0_ISSUER_BASE_URL and ' +
+        'MCP_AUTH0_AUDIENCE (or neither, to run /mcp unauthenticated).'
+    );
   }
   return { issuerBaseURL, audience, resource: env['MCP_RESOURCE'] ?? audience };
 }

--- a/src/server/mcp/http.integration.spec.ts
+++ b/src/server/mcp/http.integration.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment node
+ *
+ * End-to-end test of the HTTP mounting over the wire: a real Express app (with the global
+ * JSON body parser, as in server.ts) driven with raw MCP JSON-RPC via `fetch`. Exercises
+ * what http.spec.ts cannot — body handoff to the transport, the request cast, the
+ * per-request server/transport lifecycle, and real initialize / tools/list / tools/call
+ * responses.
+ *
+ * Uses raw fetch rather than the SDK's StreamableHTTPClientTransport because that client
+ * module pulls in an ESM-only dependency the jest runtime cannot load.
+ */
+import express from 'express';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import { mountMcp } from './http';
+import { McpServices } from './services';
+
+interface RpcResponse {
+  status: number;
+  json: { result?: { tools?: { name: string }[]; content?: { text: string }[] }; error?: unknown };
+}
+
+describe('MCP over real HTTP (raw JSON-RPC)', () => {
+  let server: Server;
+  let url: string;
+  let warnSpy: jest.SpyInstance;
+  const services = {
+    ahb: { getAhb: jest.fn(), searchAhbLines: jest.fn() },
+    ahbDiff: { getDiff: jest.fn(), getSummary: jest.fn() },
+    metadata: {
+      listFormatVersions: jest.fn(),
+      listFormate: jest.fn(),
+      listDirections: jest.fn(),
+      getDatenstand: jest.fn(),
+      listPruefisByFormatVersion: jest.fn(),
+    },
+  };
+
+  beforeAll(done => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const app = express();
+    app.use(express.json());
+    mountMcp(app, { services: services as unknown as McpServices, authConfig: null });
+    server = app.listen(0, () => {
+      url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+      done();
+    });
+  });
+
+  afterAll(done => {
+    warnSpy.mockRestore();
+    server.close(() => done());
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  async function rpc(body: Record<string, unknown>): Promise<RpcResponse> {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    const contentType = res.headers.get('content-type') ?? '';
+    let json: RpcResponse['json'] = {};
+    if (contentType.includes('application/json')) {
+      json = JSON.parse(text);
+    } else {
+      // Streamable HTTP returns the JSON-RPC response as an SSE `data:` line.
+      const dataLine = text.split('\n').find(line => line.startsWith('data:'));
+      if (dataLine) {
+        json = JSON.parse(dataLine.slice('data:'.length).trim());
+      }
+    }
+    return { status: res.status, json };
+  }
+
+  const initialize = (): Promise<RpcResponse> =>
+    rpc({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'e2e', version: '1' },
+      },
+    });
+
+  it('handles initialize over HTTP', async () => {
+    const res = await initialize();
+    expect(res.status).toBe(200);
+    expect(res.json.result).toBeDefined();
+  });
+
+  it('lists all tools (stateless: fresh server per request, no prior init)', async () => {
+    const res = await rpc({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+    expect(res.status).toBe(200);
+    expect(res.json.result?.tools).toHaveLength(9);
+  });
+
+  it('invokes a tool end-to-end, forwarding the parsed body to the service', async () => {
+    services.metadata.listFormatVersions.mockResolvedValue(['FV2410', 'FV2504']);
+
+    const res = await rpc({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'list_format_versions', arguments: {} },
+    });
+
+    expect(res.status).toBe(200);
+    expect(services.metadata.listFormatVersions).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(res.json.result!.content![0].text)).toEqual(['FV2410', 'FV2504']);
+  });
+});

--- a/src/server/mcp/http.spec.ts
+++ b/src/server/mcp/http.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ *
+ * The Streamable HTTP transport relies on Node stream/web globals absent in jsdom, so this
+ * suite runs in the node environment.
+ */
+import type { Application } from 'express';
+
+// See auth.spec.ts — mock the JWT lib so jsdom does not try to parse jose's ESM build.
+jest.mock('express-oauth2-jwt-bearer', () => ({
+  auth: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import { mountMcp } from './http';
+import { McpAuthConfig } from './auth';
+
+interface RouteRecord {
+  method: string;
+  path: string;
+}
+
+/** Minimal fake Express app that records route registrations. */
+function fakeApp(): { app: Application; routes: RouteRecord[] } {
+  const routes: RouteRecord[] = [];
+  const record =
+    (method: string) =>
+    (path: string, ...handlers: unknown[]) => {
+      routes.push({ method, path });
+      return handlers;
+    };
+  const app = { get: record('get'), post: record('post'), delete: record('delete') };
+  return { app: app as unknown as Application, routes };
+}
+
+const authConfig: McpAuthConfig = {
+  issuerBaseURL: 'https://auth.hochfrequenz.de/',
+  audience: 'https://host/mcp',
+  resource: 'https://host/mcp',
+};
+
+describe('mountMcp', () => {
+  it('registers the MCP endpoint for POST and rejects GET/DELETE (stateless)', () => {
+    const { app, routes } = fakeApp();
+    mountMcp(app, { authConfig: null });
+
+    expect(routes).toContainEqual({ method: 'post', path: '/mcp' });
+    expect(routes).toContainEqual({ method: 'get', path: '/mcp' });
+    expect(routes).toContainEqual({ method: 'delete', path: '/mcp' });
+  });
+
+  it('does not register OAuth metadata when auth is disabled', () => {
+    const { app, routes } = fakeApp();
+    mountMcp(app, { authConfig: null });
+
+    expect(routes.some(r => r.path.startsWith('/.well-known'))).toBe(false);
+  });
+
+  it('registers the RFC 9728 metadata routes (path-inserted + root) when auth is configured', () => {
+    const { app, routes } = fakeApp();
+    mountMcp(app, { authConfig });
+
+    expect(routes).toContainEqual({
+      method: 'get',
+      path: '/.well-known/oauth-protected-resource/mcp',
+    });
+    expect(routes).toContainEqual({
+      method: 'get',
+      path: '/.well-known/oauth-protected-resource',
+    });
+  });
+});

--- a/src/server/mcp/http.ts
+++ b/src/server/mcp/http.ts
@@ -31,6 +31,13 @@ export function mountMcp(app: Application, options: MountMcpOptions = {}): void 
     options.authConfig === null ? undefined : (options.authConfig ?? loadMcpAuthConfig());
   const version = options.version ?? process.env['VERSION'] ?? '0.0.0';
 
+  if (!authConfig) {
+    console.warn(
+      '[mcp] Auth is DISABLED — /mcp is publicly accessible. Set MCP_AUTH0_ISSUER_BASE_URL ' +
+        'and MCP_AUTH0_AUDIENCE to protect it with Auth0.'
+    );
+  }
+
   if (authConfig) {
     const metadata = protectedResourceMetadata(authConfig);
     const serveMetadata: RequestHandler = (_req, res) => {

--- a/src/server/mcp/http.ts
+++ b/src/server/mcp/http.ts
@@ -1,0 +1,78 @@
+import { Application, Request, RequestHandler, Response } from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { buildMcpServer } from './server';
+import { createMcpServices, McpServices } from './services';
+import {
+  MCP_PATH,
+  McpAuthConfig,
+  loadMcpAuthConfig,
+  protectedResourceMetadata,
+  requireBearer,
+} from './auth';
+
+export interface MountMcpOptions {
+  services?: McpServices;
+  /** Auth config; when omitted it is read from the environment. `null` forces no auth. */
+  authConfig?: McpAuthConfig | null;
+  version?: string;
+}
+
+/**
+ * Mount the MCP server on an Express app at `/mcp` using the Streamable HTTP transport in
+ * stateless mode (fresh server + transport per request — appropriate for a read-only query
+ * server behind a load balancer).
+ *
+ * MUST be called before the static/catch-all routes in `server.ts` so `/mcp` and the
+ * `.well-known` metadata route are not shadowed by the SPA fallback.
+ */
+export function mountMcp(app: Application, options: MountMcpOptions = {}): void {
+  const services = options.services ?? createMcpServices();
+  const authConfig =
+    options.authConfig === null ? undefined : (options.authConfig ?? loadMcpAuthConfig());
+  const version = options.version ?? process.env['VERSION'] ?? '0.0.0';
+
+  if (authConfig) {
+    const metadata = protectedResourceMetadata(authConfig);
+    const serveMetadata: RequestHandler = (_req, res) => {
+      res.status(200).json(metadata);
+    };
+    // RFC 9728 path-inserted location (primary) plus the root path (fallback).
+    app.get('/.well-known/oauth-protected-resource/mcp', serveMetadata);
+    app.get('/.well-known/oauth-protected-resource', serveMetadata);
+  }
+
+  const guards: RequestHandler[] = authConfig ? [requireBearer(authConfig)] : [];
+
+  app.post(MCP_PATH, ...guards, async (req: Request, res: Response) => {
+    // Stateless: a new server + transport per request (no session reuse).
+    const server = buildMcpServer(services, version);
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    res.on('close', () => {
+      void transport.close();
+      void server.close();
+    });
+    try {
+      await server.connect(transport);
+      // Global express.json() already parsed the body — pass it explicitly so the
+      // transport does not try to re-read the consumed stream. `req` is cast to the
+      // transport's expected node request type (express-oauth2-jwt-bearer augments
+      // Express's `Request.auth` differently from the SDK's `AuthInfo`).
+      await transport.handleRequest(
+        req as unknown as Parameters<typeof transport.handleRequest>[0],
+        res,
+        req.body
+      );
+    } catch (error) {
+      console.error('MCP request handling error:', error);
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'internal_error' });
+      }
+    }
+  });
+
+  const methodNotAllowed: RequestHandler = (_req, res) => {
+    res.status(405).json({ error: 'method_not_allowed', message: 'Use POST for MCP requests' });
+  };
+  app.get(MCP_PATH, ...guards, methodNotAllowed);
+  app.delete(MCP_PATH, ...guards, methodNotAllowed);
+}

--- a/src/server/mcp/result.spec.ts
+++ b/src/server/mcp/result.spec.ts
@@ -1,0 +1,63 @@
+import { jsonResult, errorResult, toToolResult } from './result';
+import { ValidationError, NotFoundError } from '../infrastructure/errors';
+
+describe('mcp/result', () => {
+  describe('jsonResult', () => {
+    it('wraps data as pretty-printed JSON text content', () => {
+      const result = jsonResult({ a: 1 });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify({ a: 1 }, null, 2) }],
+      });
+      expect(result.isError).toBeUndefined();
+    });
+  });
+
+  describe('errorResult', () => {
+    it('marks the result as an error with the message text', () => {
+      expect(errorResult('boom')).toEqual({
+        content: [{ type: 'text', text: 'boom' }],
+        isError: true,
+      });
+    });
+  });
+
+  describe('toToolResult', () => {
+    it('returns a JSON result on success', async () => {
+      const result = await toToolResult(async () => ['FV2410', 'FV2504']);
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual([
+        'FV2410',
+        'FV2504',
+      ]);
+    });
+
+    it('maps a ValidationError to a curated isError result', async () => {
+      const result = await toToolResult(async () => {
+        throw new ValidationError('bad pruefi');
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toBe('VALIDATION_ERROR: bad pruefi');
+    });
+
+    it('maps a NotFoundError to a curated isError result', async () => {
+      const result = await toToolResult(async () => {
+        throw new NotFoundError('nope');
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toBe('NOT_FOUND: nope');
+    });
+
+    it('maps unexpected errors to a generic isError result without leaking details', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const result = await toToolResult(async () => {
+        throw new Error('secret internal detail');
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toBe(
+        'INTERNAL_ERROR: An unexpected error occurred'
+      );
+      expect((result.content[0] as { text: string }).text).not.toContain('secret internal detail');
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/server/mcp/result.ts
+++ b/src/server/mcp/result.ts
@@ -1,0 +1,41 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { AppError } from '../infrastructure/errors';
+
+/**
+ * MCP tool result alias. Typed as the SDK's `CallToolResult` via a type-only import (erased
+ * at runtime, so this module stays free of runtime SDK loading and is unit-testable).
+ */
+export type ToolResult = CallToolResult;
+
+/** Wrap data as a JSON text result. */
+export function jsonResult(data: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}
+
+/** An error result the model can see and react to (`isError: true`). */
+export function errorResult(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+/**
+ * Run a service call and map the outcome to a tool result.
+ *
+ * - Success → JSON text result.
+ * - Expected domain errors (`AppError`: validation / not-found / ...) → `isError` result
+ *   carrying the curated `errorCode: message`, mirroring `httpErrorHandler`.
+ * - Unexpected errors → generic `isError` result (details logged, not leaked to the client).
+ *
+ * Domain/unexpected errors are returned as tool results (not thrown) so the model sees
+ * them; only transport-level auth failures are surfaced as protocol errors upstream.
+ */
+export async function toToolResult(fn: () => Promise<unknown>): Promise<ToolResult> {
+  try {
+    return jsonResult(await fn());
+  } catch (error) {
+    if (error instanceof AppError) {
+      return errorResult(`${error.errorCode}: ${error.message}`);
+    }
+    console.error('Unexpected error in MCP tool handler:', error);
+    return errorResult('INTERNAL_ERROR: An unexpected error occurred');
+  }
+}

--- a/src/server/mcp/server.spec.ts
+++ b/src/server/mcp/server.spec.ts
@@ -1,0 +1,168 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { buildMcpServer } from './server';
+import { MCP_TOOL_NAMES } from './tools';
+import { McpServices } from './services';
+import { ValidationError } from '../infrastructure/errors';
+
+interface CallResult {
+  isError?: boolean;
+  content: { type: string; text: string }[];
+}
+
+function parse(result: CallResult): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('MCP server (in-memory integration)', () => {
+  let services: {
+    ahb: { getAhb: jest.Mock; searchAhbLines: jest.Mock };
+    ahbDiff: { getDiff: jest.Mock; getSummary: jest.Mock };
+    metadata: {
+      listFormatVersions: jest.Mock;
+      listFormate: jest.Mock;
+      listDirections: jest.Mock;
+      getDatenstand: jest.Mock;
+      listPruefisByFormatVersion: jest.Mock;
+    };
+  };
+  let client: Client;
+
+  beforeEach(async () => {
+    services = {
+      ahb: { getAhb: jest.fn(), searchAhbLines: jest.fn() },
+      ahbDiff: { getDiff: jest.fn(), getSummary: jest.fn() },
+      metadata: {
+        listFormatVersions: jest.fn(),
+        listFormate: jest.fn(),
+        listDirections: jest.fn(),
+        getDatenstand: jest.fn(),
+        listPruefisByFormatVersion: jest.fn(),
+      },
+    };
+
+    const server = buildMcpServer(services as unknown as McpServices, 'test');
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'test-client', version: '1.0.0' });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  describe('listTools', () => {
+    it('exposes exactly the AHB tools, all annotated read-only', async () => {
+      const { tools } = await client.listTools();
+      expect(tools.map(t => t.name).sort()).toEqual([...MCP_TOOL_NAMES].sort());
+      for (const tool of tools) {
+        expect(tool.annotations?.readOnlyHint).toBe(true);
+        expect(tool.description).toBeTruthy();
+      }
+    });
+  });
+
+  describe('tool calls delegate to the services', () => {
+    it('get_ahb returns the JSON AHB content', async () => {
+      const ahb = { meta: { pruefidentifikator: '11001' }, lines: [] };
+      services.ahb.getAhb.mockResolvedValue({ fileType: 'json', content: ahb });
+
+      const result = (await client.callTool({
+        name: 'get_ahb',
+        arguments: { formatVersion: 'FV2410', pruefi: '11001' },
+      })) as CallResult;
+
+      expect(services.ahb.getAhb).toHaveBeenCalledWith('11001', 'FV2410', 'json');
+      expect(result.isError).toBeFalsy();
+      expect(parse(result)).toEqual(ahb);
+    });
+
+    it('search_ahb_lines forwards the validated payload', async () => {
+      const searchResult = { items: [], total: 0, page: 1, pageSize: 25 };
+      services.ahb.searchAhbLines.mockResolvedValue(searchResult);
+
+      const result = (await client.callTool({
+        name: 'search_ahb_lines',
+        arguments: {
+          q: 'test',
+          page: 1,
+          pageSize: 25,
+          sort: [{ field: 'format_version', direction: 'asc' }],
+          filters: { format: { eq: 'UTILMD' }, sender: { in: ['LF'] } },
+        },
+      })) as CallResult;
+
+      expect(services.ahb.searchAhbLines).toHaveBeenCalledWith({
+        q: 'test',
+        page: 1,
+        pageSize: 25,
+        sort: [{ field: 'format_version', direction: 'asc' }],
+        filters: { format: { eq: 'UTILMD' }, sender: { in: ['LF'] } },
+      });
+      expect(parse(result)).toEqual(searchResult);
+    });
+
+    it('get_ahb_diff_summary returns the summary', async () => {
+      const summary = { '11001': { added: 1, deleted: 0, modified: 2 } };
+      services.ahbDiff.getSummary.mockResolvedValue(summary);
+
+      const result = (await client.callTool({
+        name: 'get_ahb_diff_summary',
+        arguments: { formatVersionNew: 'FV2504', formatVersionOld: 'FV2410' },
+      })) as CallResult;
+
+      expect(services.ahbDiff.getSummary).toHaveBeenCalledWith('FV2504', 'FV2410');
+      expect(parse(result)).toEqual(summary);
+    });
+
+    it('list_format_versions takes no arguments', async () => {
+      services.metadata.listFormatVersions.mockResolvedValue(['FV2410', 'FV2504']);
+
+      const result = (await client.callTool({
+        name: 'list_format_versions',
+        arguments: {},
+      })) as CallResult;
+
+      expect(parse(result)).toEqual(['FV2410', 'FV2504']);
+    });
+
+    it('list_pruefis_by_format_version passes the format version', async () => {
+      services.metadata.listPruefisByFormatVersion.mockResolvedValue([
+        { pruefidentifikator: '11001', name: 'x' },
+      ]);
+
+      await client.callTool({
+        name: 'list_pruefis_by_format_version',
+        arguments: { formatVersion: 'FV2410' },
+      });
+
+      expect(services.metadata.listPruefisByFormatVersion).toHaveBeenCalledWith('FV2410');
+    });
+  });
+
+  describe('error handling', () => {
+    it('maps a service ValidationError to an isError tool result', async () => {
+      services.ahb.getAhb.mockRejectedValue(new ValidationError('Invalid Prüfidentifikator'));
+
+      const result = (await client.callTool({
+        name: 'get_ahb',
+        arguments: { formatVersion: 'FV2410', pruefi: '99999' },
+      })) as CallResult;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('VALIDATION_ERROR: Invalid Prüfidentifikator');
+    });
+
+    it('returns a schema-validation error without invoking the service', async () => {
+      const result = (await client.callTool({
+        name: 'get_ahb',
+        arguments: { formatVersion: 'FV2410' },
+      })) as CallResult;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('validation');
+      expect(services.ahb.getAhb).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -1,0 +1,18 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServices, createMcpServices } from './services';
+import { registerAhbTools } from './tools';
+
+export const MCP_SERVER_NAME = 'ahb-tabellen';
+
+/**
+ * Build an `McpServer` with all AHB tools registered against the given services.
+ * A fresh instance is cheap; the HTTP layer builds one per request in stateless mode.
+ */
+export function buildMcpServer(
+  services: McpServices = createMcpServices(),
+  version = '1.0.0'
+): McpServer {
+  const server = new McpServer({ name: MCP_SERVER_NAME, version });
+  registerAhbTools(server, services);
+  return server;
+}

--- a/src/server/mcp/server.ts
+++ b/src/server/mcp/server.ts
@@ -10,7 +10,7 @@ export const MCP_SERVER_NAME = 'ahb-tabellen';
  */
 export function buildMcpServer(
   services: McpServices = createMcpServices(),
-  version = '1.0.0'
+  version = '0.0.0'
 ): McpServer {
   const server = new McpServer({ name: MCP_SERVER_NAME, version });
   registerAhbTools(server, services);

--- a/src/server/mcp/services.ts
+++ b/src/server/mcp/services.ts
@@ -1,0 +1,21 @@
+import AhbService from '../service/ahb.service';
+import AhbDiffService from '../service/ahbDiff.service';
+import MetadataService from '../service/metadata.service';
+
+/**
+ * The transport-agnostic services the MCP tools delegate to. Bundled so the tool
+ * handlers can be constructed and unit-tested with mocked services.
+ */
+export interface McpServices {
+  ahb: AhbService;
+  ahbDiff: AhbDiffService;
+  metadata: MetadataService;
+}
+
+export function createMcpServices(): McpServices {
+  return {
+    ahb: new AhbService(),
+    ahbDiff: new AhbDiffService(),
+    metadata: new MetadataService(),
+  };
+}

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -1,0 +1,196 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServices } from './services';
+import { toToolResult } from './result';
+import { SearchPayload } from '../repository/ahb';
+
+/**
+ * All AHB tools are read-only queries over a fixed data set.
+ * `as const` so the literal boolean values are preserved for the SDK's `ToolAnnotations`.
+ */
+const READ_ONLY = { readOnlyHint: true, openWorldHint: false } as const;
+
+const FORMAT_VERSION_DESC = 'EDIFACT format version, pattern FVYYYY (e.g. "FV2410").';
+const PRUEFI_DESC = 'Prüfidentifikator: exactly 5 digits (e.g. "11001").';
+
+/** Names of all registered MCP tools, in registration order (used by tests). */
+export const MCP_TOOL_NAMES = [
+  'get_ahb',
+  'search_ahb_lines',
+  'get_ahb_diff',
+  'get_ahb_diff_summary',
+  'list_format_versions',
+  'list_formate',
+  'list_directions',
+  'get_datenstand',
+  'list_pruefis_by_format_version',
+] as const;
+
+const searchFilterCondition = z.object({
+  eq: z.string().optional(),
+  neq: z.string().optional(),
+  contains: z.string().optional(),
+  startsWith: z.string().optional(),
+  endsWith: z.string().optional(),
+  in: z.array(z.string()).optional(),
+  isNull: z.boolean().optional(),
+  isNotNull: z.boolean().optional(),
+});
+
+const searchFilters = z
+  .object({
+    format_version: searchFilterCondition,
+    format: searchFilterCondition,
+    pruefidentifikator: searchFilterCondition,
+    description: searchFilterCondition,
+    segmentgroup_key: searchFilterCondition,
+    segment_code: searchFilterCondition,
+    data_element: searchFilterCondition,
+    qualifier: searchFilterCondition,
+    line_ahb_status: searchFilterCondition,
+    line_name: searchFilterCondition,
+    bedingung: searchFilterCondition,
+    sender: searchFilterCondition,
+    empfaenger: searchFilterCondition,
+  })
+  .partial();
+
+/**
+ * Register all AHB tools on an `McpServer`. Handlers are registered inline so the SDK
+ * infers each handler's argument types directly from its zod `inputSchema` — args are
+ * fully typed (e.g. `pruefi: string`), with no stringly-typed access and no casts.
+ */
+export function registerAhbTools(server: McpServer, services: McpServices): void {
+  server.registerTool(
+    'get_ahb',
+    {
+      title: 'Get AHB',
+      description:
+        'Retrieve a single Anwendungshandbuch (AHB) as JSON for a Prüfidentifikator in a ' +
+        'given format version.',
+      inputSchema: {
+        formatVersion: z.string().describe(FORMAT_VERSION_DESC),
+        pruefi: z.string().describe(PRUEFI_DESC),
+      },
+      annotations: { ...READ_ONLY, title: 'Get AHB' },
+    },
+    async ({ formatVersion, pruefi }) =>
+      toToolResult(async () => (await services.ahb.getAhb(pruefi, formatVersion, 'json')).content)
+  );
+
+  server.registerTool(
+    'search_ahb_lines',
+    {
+      title: 'Search AHB lines',
+      description:
+        'Full-text and filtered search across AHB lines of all format versions. Supports ' +
+        'pagination, sorting, and per-field filters (eq/neq/contains/startsWith/endsWith/in/' +
+        'isNull/isNotNull), including the virtual sender/empfaenger direction fields.',
+      inputSchema: {
+        q: z.string().describe('Full-text query; use an empty string to match all lines.'),
+        page: z.number().int().min(1).describe('1-based page number.'),
+        pageSize: z.number().int().min(1).max(500).describe('Results per page (1–500).'),
+        sort: z
+          .array(z.object({ field: z.string(), direction: z.enum(['asc', 'desc']).optional() }))
+          .describe('Sort order; may be an empty array.'),
+        filters: searchFilters.optional().describe('Optional per-field filter conditions.'),
+      },
+      annotations: { ...READ_ONLY, title: 'Search AHB lines' },
+    },
+    async ({ q, page, pageSize, sort, filters }) =>
+      toToolResult(() => {
+        const payload: SearchPayload = { q, page, pageSize, sort, filters };
+        return services.ahb.searchAhbLines(payload);
+      })
+  );
+
+  server.registerTool(
+    'get_ahb_diff',
+    {
+      title: 'Get AHB diff',
+      description:
+        'Line-level diff of one Prüfidentifikator between two format versions (added / ' +
+        'deleted / modified / unchanged lines with old and new values).',
+      inputSchema: {
+        pruefi: z.string().describe(PRUEFI_DESC),
+        formatVersionNew: z.string().describe('Newer ' + FORMAT_VERSION_DESC),
+        formatVersionOld: z.string().describe('Older ' + FORMAT_VERSION_DESC),
+      },
+      annotations: { ...READ_ONLY, title: 'Get AHB diff' },
+    },
+    async ({ pruefi, formatVersionNew, formatVersionOld }) =>
+      toToolResult(() => services.ahbDiff.getDiff(pruefi, formatVersionNew, formatVersionOld))
+  );
+
+  server.registerTool(
+    'get_ahb_diff_summary',
+    {
+      title: 'Get AHB diff summary',
+      description:
+        'Per-Prüfidentifikator change counts (added / deleted / modified) between two ' +
+        'format versions.',
+      inputSchema: {
+        formatVersionNew: z.string().describe('Newer ' + FORMAT_VERSION_DESC),
+        formatVersionOld: z.string().describe('Older ' + FORMAT_VERSION_DESC),
+      },
+      annotations: { ...READ_ONLY, title: 'Get AHB diff summary' },
+    },
+    async ({ formatVersionNew, formatVersionOld }) =>
+      toToolResult(() => services.ahbDiff.getSummary(formatVersionNew, formatVersionOld))
+  );
+
+  server.registerTool(
+    'list_format_versions',
+    {
+      title: 'List format versions',
+      description: 'List all available EDIFACT format versions (e.g. FV2410).',
+      annotations: { ...READ_ONLY, title: 'List format versions' },
+    },
+    async () => toToolResult(() => services.metadata.listFormatVersions())
+  );
+
+  server.registerTool(
+    'list_formate',
+    {
+      title: 'List formats',
+      description: 'List all available EDIFACT formats (e.g. UTILMD, MSCONS).',
+      annotations: { ...READ_ONLY, title: 'List formats' },
+    },
+    async () => toToolResult(() => services.metadata.listFormate())
+  );
+
+  server.registerTool(
+    'list_directions',
+    {
+      title: 'List direction values',
+      description: 'List the distinct sender and empfaenger (recipient) direction values.',
+      annotations: { ...READ_ONLY, title: 'List direction values' },
+    },
+    async () => toToolResult(() => services.metadata.listDirections())
+  );
+
+  server.registerTool(
+    'get_datenstand',
+    {
+      title: 'Get Datenstand',
+      description: 'Get the latest Veröffentlichungsdatum (publication date) of the data set.',
+      annotations: { ...READ_ONLY, title: 'Get Datenstand' },
+    },
+    async () => toToolResult(() => services.metadata.getDatenstand())
+  );
+
+  server.registerTool(
+    'list_pruefis_by_format_version',
+    {
+      title: 'List Prüfidentifikatoren by format version',
+      description:
+        'List all Prüfidentifikatoren (with descriptions) available in a given format version.',
+      inputSchema: {
+        formatVersion: z.string().describe(FORMAT_VERSION_DESC),
+      },
+      annotations: { ...READ_ONLY, title: 'List Prüfidentifikatoren by format version' },
+    },
+    async ({ formatVersion }) =>
+      toToolResult(() => services.metadata.listPruefisByFormatVersion(formatVersion))
+  );
+}


### PR DESCRIPTION
## Why

Round 2 of exposing the AHB backend to AI assistants: a **Model Context Protocol server over Streamable HTTP**, mounted on the existing Express app at `/mcp`, reusing the Round-1 service layer (PR #835). Plan: `docs/plans/2026-07-06-mcp-server-round2.md`.

## What

**9 read-only tools**, thin adapters over `src/server/service/*` (zero business-logic duplication):
`get_ahb`, `search_ahb_lines`, `get_ahb_diff`, `get_ahb_diff_summary`, `list_format_versions`, `list_formate`, `list_directions`, `get_datenstand`, `list_pruefis_by_format_version`.

- **`tools.ts`** — inline SDK registration; each handler's args are fully typed from its zod `inputSchema` (no stringly-typing, no casts in handler bodies).
- **`result.ts`** — JSON/error tool-result helpers; `AppError` → `isError` tool result, unexpected errors → generic message (details logged, not leaked).
- **`auth.ts`** — Auth0 resource-server guard: RFC 9728 Protected Resource Metadata, `WWW-Authenticate` 401 pointer, bearer validation via `express-oauth2-jwt-bearer` (injectable for tests). Auth is active only when `MCP_AUTH0_*` env vars are set; **REST stays open** so the webapp is unaffected.
- **`http.ts`** — stateless Streamable HTTP transport, mounted **before** the static catch-alls, passing the pre-parsed `req.body` to `handleRequest` (co-hosting hazards from the plan review).

## Framework

Official **`@modelcontextprotocol/sdk`** (`McpServer` + `StreamableHTTPServerTransport`) + `express-oauth2-jwt-bearer` + `zod`. No third-party wrapper. SDK is a dual CJS/ESM build, so it works with the CommonJS server; verified TS resolution and runtime.

## Testing (SDK + Auth0 best practices)

- **In-memory `Client`↔`Server` round-trip** (SDK's documented pattern) exercises every tool, delegation, error mapping, and schema validation.
- **Real bearer-auth integration test**: a live Express server + the actual middleware, driven over HTTP with signed JWTs — asserts accept (valid) and reject (missing / wrong-audience / expired / tampered).
- Unit tests for result mapping, RFC 9728 metadata, and route mounting.
- Full suite: **304 tests green**; `server:build`, `server:lint`, prettier all pass.

## Auth setup (deploy-time, not in this PR)

Create an Auth0 API whose identifier = the canonical MCP URL, then set `MCP_AUTH0_ISSUER_BASE_URL` + `MCP_AUTH0_AUDIENCE`. DCR/PKCE/metadata already exist on the tenant.

## Not in scope / to verify

- **RFC 8707 `resource` vs Auth0 `audience`** must be validated end-to-end with a real MCP client against stage (highest-uncertainty item; see plan risk #1).
- REST-API auth + Angular token wiring (future round).
- Optional `ahb://` resource template (deferred pending client validation).

## Docs

README MCP section (tools, auth, client config for **Claude / GitHub Copilot / opencode**); `.example.env` MCP vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)