### PR TITLE
chore(pulumi): MCP Auth0 config for prod stack (stacked on #836)

### DIFF
--- a/pulumi/Pulumi.prod.yaml
+++ b/pulumi/Pulumi.prod.yaml
@@ -12,6 +12,8 @@ config:
     secure: AAABAPxqz5l9dn9CRjuSdmBw1dz+WQpoqfXJ1pRz5SzsxAuKHMB8mOo+Ir3nCllS0u8VjraFpDnDqGq1SA5a6RbNeOl49eJ+
   ahb-tabellen:imageName: ghcr.io/hochfrequenz/ahb-tabellen
   ahb-tabellen:imageTag: v1.4.0
+  ahb-tabellen:mcpAuth0Audience: https://ahb-tabellen.hochfrequenz.de/mcp
+  ahb-tabellen:mcpAuth0IssuerBaseUrl: https://auth.hochfrequenz.de/
   ahb-tabellen:ohDearHealthCheckSecret:
     secure: AAABANrflh/RuuKGiZEPld6MZksWHZZsRfivLLSXEW7gMaC0k+omHcGtixSle5ok
   ahb-tabellen:websitesContainerStartTimeLimit: "300"


### PR DESCRIPTION
> 🥞 **STACKED PR — Basis ist `feat/mcp-server` (PR #836), NICHT `main`.**
> Dieser PR baut auf #836 auf und zeigt nur den zusätzlichen Prod-Config-Diff.
> **Bitte nicht eigenständig mergen.** Reihenfolge:
> 1. **#836** zuerst nach `main` (Squash),
> 2. diesen PR auf `main` **retargeten/rebasen**, dann mergen,
> 3. **danach** erst `v1.9.0` (Nicht-rc) releasen.
> Solange die Basis `feat/mcp-server` ist, enthält der Diff hier nur die 2 Prod-Zeilen; nach dem Retarget auf `main` bleibt es dabei.

---

Bereitet die **Prod**-Aktivierung des MCP-Servers vor — **deployt nichts**, bis gemergt **und** ein Nicht-rc-Release (`v1.9.0`) mit Octopus-Freigabe läuft.

## Änderung
`Pulumi.prod.yaml`: `mcpAuth0IssuerBaseUrl` + `mcpAuth0Audience` (= `https://ahb-tabellen.hochfrequenz.de/mcp`) gesetzt → beim nächsten Prod-Deploy erzwingt `/mcp` Auth0 (analog Stage). Nicht-geheime Werte.

## ⚠️ Reihenfolge (kritisch)
Die **Prod-Auth0-API** (Identifier = `https://ahb-tabellen.hochfrequenz.de/mcp`, RS256) + Third-Party-Grant (**#849**) **muss existieren, bevor** `v1.9.0` auf Prod deployt — sonst `/mcp` = 401 für alle. Tenant-weite Voraussetzungen (Resource-Parameter-Profil, DCR, domain-level Connection) sind aus dem Stage-Setup **schon aktiv**.

Kontext: Tracking #845, Auth0-Prod-Ticket #849. Unabhängig reviewt (Pulumi-Diff + #849) — beide korrekt.
