### PR TITLE
docs(mcp): note where to paste the opencode config on the integration page

### DIFF
--- a/src/app/features/mcp-info/mcp-info.component.html
+++ b/src/app/features/mcp-info/mcp-info.component.html
@@ -109,8 +109,8 @@
             <span class="mdi mdi-open-in-new text-base"></span>
           </a>
           <p class="text-xs md:text-sm mt-1 opacity-70">
-            In deine <code class="font-mono">opencode.json</code> eintragen (Projekt-Wurzel oder
-            global unter <code class="font-mono">~/.config/opencode/opencode.json</code>):
+            In deine <code class="font-mono">opencode.json</code> eintragen (Repo-Root oder global
+            unter <code class="font-mono">~/.config/opencode/opencode.json</code>):
           </p>
           <pre
             class="mt-1 rounded-lg bg-hf-weiss-rose border border-hf-grell-rose px-3 py-2 font-mono text-xs overflow-x-auto"><code>{{ opencodeConfig }}</code></pre>

--- a/src/app/features/mcp-info/mcp-info.component.html
+++ b/src/app/features/mcp-info/mcp-info.component.html
@@ -108,6 +108,10 @@
             opencode
             <span class="mdi mdi-open-in-new text-base"></span>
           </a>
+          <p class="text-xs md:text-sm mt-1 opacity-70">
+            In deine <code class="font-mono">opencode.json</code> eintragen (Projekt-Wurzel oder
+            global unter <code class="font-mono">~/.config/opencode/opencode.json</code>):
+          </p>
           <pre
             class="mt-1 rounded-lg bg-hf-weiss-rose border border-hf-grell-rose px-3 py-2 font-mono text-xs overflow-x-auto"><code>{{ opencodeConfig }}</code></pre>
           <p class="text-xs md:text-sm mt-1 opacity-70">Danach einmalig anmelden:</p>


### PR DESCRIPTION
Kleiner UX-Zusatz auf `/mcp-integration`: ein Satz **vor** dem opencode-Snippet, wo die Config hingehört — `opencode.json` (Projekt-Wurzel) oder global `~/.config/opencode/opencode.json` (verifiziert gegen opencode-Doku).

Die Server-URL im Snippet bleibt **dynamisch** (aus `window.location.origin`, also automatisch Stage vs. Prod).

Build + Lint + Component-Test grün.