### PR TITLE
fix: LF for shell scripts (#563) + AHB table bottom padding (#804)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 CHANGELOG.md linguist-generated=true
 src/app/core/api/**/* linguist-generated=true
+
+# Shell scripts must keep LF endings so they run on containers even when checked
+# out on Windows (fixes "set: line 4: illegal option" from CRLF). See #563.
+*.sh text eol=lf

--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
@@ -41,7 +41,7 @@
   </app-header>
 
   <!-- Scrollable Content -->
-  <div #scroll class="flex-1 overflow-auto relative bg-hf-pastell-rot" *ngIf="!errorOccurred">
+  <div #scroll class="flex-1 overflow-auto relative bg-hf-pastell-rot pb-10" *ngIf="!errorOccurred">
     <!-- Metadata Section -->
     @if (ahb$ | async; as ahb) {
       <div class="flex flex-col md:flex-row mb-10">


### PR DESCRIPTION
Zwei kleine Quick-Wins:

- **#563** — `.gitattributes`: `*.sh text eol=lf`. `start.sh` (und andere `.sh`) behalten damit auf Windows-Checkouts LF-Zeilenenden → behebt `set: line 4: illegal option` (CRLF-Ursache). `start.sh` ist bereits LF; das Attribut hält es dauerhaft so.
- **#804** — `ahb-page`: `pb-10` am scrollbaren Content, damit die AHB-Tabelle nicht mehr direkt an den (ähnlich gefärbten) Footer stößt.

Lint + Build grün. Closes #563, closes #804.