### PR TITLE
fix: force LF line endings for shell scripts (#563)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 CHANGELOG.md linguist-generated=true
 src/app/core/api/**/* linguist-generated=true
+
+# Shell scripts must keep LF endings so they run on containers even when checked
+# out on Windows (fixes "set: line 4: illegal option" from CRLF). See #563.
+*.sh text eol=lf


### PR DESCRIPTION
`.gitattributes`: `*.sh text eol=lf` → `start.sh` (und andere `.sh`) behalten auf Windows-Checkouts LF-Zeilenenden, was den Fehler `set: line 4: illegal option` (CRLF-Ursache) behebt. `start.sh` ist bereits LF; das Attribut hält es dauerhaft so. Closes #563.