### PR TITLE
fix: AHB table bottom padding so it doesn't touch the footer (#804)

### DIFF
--- a/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
+++ b/src/app/features/ahbs/views/ahb-page/ahb-page.component.html
@@ -41,7 +41,7 @@
   </app-header>
 
   <!-- Scrollable Content -->
-  <div #scroll class="flex-1 overflow-auto relative bg-hf-pastell-rot" *ngIf="!errorOccurred">
+  <div #scroll class="flex-1 overflow-auto relative bg-hf-pastell-rot pb-10" *ngIf="!errorOccurred">
     <!-- Metadata Section -->
     @if (ahb$ | async; as ahb) {
       <div class="flex flex-col md:flex-row mb-10">


### PR DESCRIPTION
`ahb-page`: `pb-10` am scrollbaren Content, damit die letzten Tabellenzeilen nicht direkt am (ähnlich gefärbten) Footer kleben. Closes #804.