### PR TITLE
docs: document that an empty `in` filter applies no constraint

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -342,7 +342,9 @@ components:
         - field
     FilterValue:
       type: object
-      description: One operator should be provided per field
+      description: >
+        One operator should be provided per field. An empty filter object `{}` applies no
+        constraint on that field.
       properties:
         eq:
           type: string
@@ -358,6 +360,11 @@ components:
           type: array
           items:
             type: string
+          description: >
+            Match any of the listed values (SQL `IN`). An **empty array is ignored** — it
+            applies no constraint on this field and therefore matches all rows, rather than
+            matching none. Omit the `in` operator (or the whole filter) when there is nothing
+            to filter by.
         isNull:
           type: boolean
         isNotNull:

--- a/src/server/repository/ahb.ts
+++ b/src/server/repository/ahb.ts
@@ -216,6 +216,10 @@ export default class AHBRepository {
             [`${paramBase}_ends`]: `%${value.endsWith.toLowerCase()}`,
           });
         }
+        // An empty `in` array applies no constraint (the field is left unfiltered), rather than
+        // matching zero rows. This is intentional and matches the frontend, which omits the `in`
+        // filter entirely when no values are selected. It also avoids an invalid `IN ()` SQL clause.
+        // Documented in openapi.yml (FilterValue.in).
         if (value.in && value.in.length > 0) {
           queryBuilder.andWhere(`al.${columnName} IN (:...${paramBase}_in)`, {
             [`${paramBase}_in`]: value.in,


### PR DESCRIPTION
Documents an undocumented, surprising-but-intentional behaviour of the search API's `in` filter operator.

## Behaviour

`{"in": []}` (empty array) applies **no constraint** on the field — it matches **all** rows, not zero. Reproduced on stage:

```bash
# in:[]  -> total 287865 (all rows)
curl -s -X POST https://ahb-tabellen.stage.hochfrequenz.de/api/search/query \
  -H 'content-type: application/json' \
  -d '{"q":"","page":1,"pageSize":1,"sort":[],"filters":{"pruefidentifikator":{"in":[]}}}'

# in:["13002"] -> total 945 (filtered)
curl -s -X POST https://ahb-tabellen.stage.hochfrequenz.de/api/search/query \
  -H 'content-type: application/json' \
  -d '{"q":"","page":1,"pageSize":1,"sort":[],"filters":{"pruefidentifikator":{"in":["13002"]}}}'
```

## Why it's intentional (not a bug)

- The frontend (`search-filters.component.ts`) only sends `{ in: values }` when `values.length > 0`, so the UI never emits an empty `in`.
- The repository guard `if (value.in && value.in.length > 0)` deliberately skips the filter for an empty array, which also avoids an invalid `IN ()` SQL clause.

It was simply undocumented, so a direct API/MCP consumer expecting empty-set (match-none) semantics could be surprised.

## Changes

- `openapi.yml`: document the empty-`in` behaviour on `FilterValue.in` and the `FilterValue` object.
- `src/server/repository/ahb.ts`: add a comment at the guard explaining the intent.

Docs/comment only — no behavioural change.
