### PR TITLE
refactor(ebd): move EBD-key detection into the business-logic layer

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -474,6 +474,11 @@ components:
               value_pool_entry:
                 type: string
                 example: 'Entry1'
+              ebd_key:
+                type: string
+                nullable: true
+                description: EBD decision-tree key (e.g. E_0401) detected in value_pool_entry, if any
+                example: 'E_0401'
               line_type:
                 type: string
                 example: 'segment'
@@ -648,6 +653,10 @@ components:
         bedingung:
           type: string
           nullable: true
+        ebd_key:
+          type: string
+          nullable: true
+          description: EBD decision-tree key (e.g. E_0401) detected in qualifier, if any
     AhbDiffSummary:
       type: object
       description: Aggregated diff statistics per Pruefidentifikator

--- a/src/app/core/api/models/ahb-diff-side.ts
+++ b/src/app/core/api/models/ahb-diff-side.ts
@@ -9,6 +9,11 @@
 export interface AhbDiffSide {
   bedingung?: string | null;
   data_element?: string | null;
+
+  /**
+   * EBD decision-tree key (e.g. E_0401) detected in qualifier, if any
+   */
+  ebd_key?: string | null;
   line_ahb_status?: string | null;
   line_name?: string | null;
   line_type?: string | null;

--- a/src/app/core/api/models/ahb.ts
+++ b/src/app/core/api/models/ahb.ts
@@ -14,6 +14,11 @@ export interface Ahb {
 'segment_code': string;
 'segment_group_key': string;
 'value_pool_entry': string;
+
+/**
+ * EBD decision-tree key (e.g. E_0401) detected in value_pool_entry, if any
+ */
+'ebd_key'?: string | null;
 'line_type': string;
 }>;
   meta: {

--- a/src/app/core/api/models/filter-value.ts
+++ b/src/app/core/api/models/filter-value.ts
@@ -4,12 +4,16 @@
 
 
 /**
- * One operator should be provided per field
+ * One operator should be provided per field. An empty filter object `{}` applies no constraint on that field.
  */
 export interface FilterValue {
   contains?: string;
   endsWith?: string;
   eq?: string;
+
+  /**
+   * Match any of the listed values (SQL `IN`). An **empty array is ignored** — it applies no constraint on this field and therefore matches all rows, rather than matching none. Omit the `in` operator (or the whole filter) when there is nothing to filter by.
+   */
   in?: Array<string>;
   isNotNull?: boolean;
   isNull?: boolean;

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
@@ -61,9 +61,9 @@
             [innerHTML]="line.segment_code | highlight: highlight()"></td>
           <td class="px-6 py-4" [innerHTML]="line.data_element | highlight: highlight()"></td>
           <td class="px-6 py-4">
-            @if (generateEbdDeepLink(line.value_pool_entry) !== null) {
+            @if (generateEbdDeepLink(line.ebd_key) !== null) {
               <a
-                [href]="generateEbdDeepLink(line.value_pool_entry)"
+                [href]="generateEbdDeepLink(line.ebd_key)"
                 target="_blank"
                 class="hover:underline font-bold text-hf-dunkel-blau flex flex-row gap-1 items-center">
                 <span [innerHTML]="line.value_pool_entry | highlight: highlight()"></span>

--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.ts
@@ -240,16 +240,11 @@ export class AhbTableComponent {
     return `${environment.bedingungsbaumBaseUrl}/tree/?format=${getFormatFromPruefi(this.pruefi())}&format_version=${this.formatVersion()}&expression=${encodedExpression}`;
   }
 
-  generateEbdDeepLink(value_pool_entry: string | null): string | null {
-    if (!value_pool_entry || value_pool_entry.trim().length === 0) {
+  generateEbdDeepLink(ebdKey: string | null | undefined): string | null {
+    if (!ebdKey) {
       return null;
     }
-    const regex = /^.*\b(?<ebd_key>E_\d+)\b.*$/;
-    const match = value_pool_entry.match(regex);
-    if (!match?.groups) {
-      return null;
-    }
-    const ebdKey = match.groups['ebd_key']!;
+    // EBD detection now happens in the backend (line.ebd_key); we only build the link.
     // e.g. https://ebd.stage.hochfrequenz.de/ebd/?formatversion=FV2504&ebd=E_0004
     return `${environment.ebdBaseUrl}/ebd/?formatversion=${this.formatVersion()}&ebd=${ebdKey}`;
   }

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.html
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.html
@@ -78,7 +78,7 @@
           <td
             class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'qualifier')">
-            @if (generateEbdDeepLink(getQualifier(line, 'old'), formatVersionOld); as ebdLink) {
+            @if (generateEbdDeepLink(line.old?.ebd_key, formatVersionOld); as ebdLink) {
               <a
                 [href]="ebdLink"
                 target="_blank"
@@ -145,7 +145,7 @@
           <td
             class="px-2 py-1.5 border-b border-hf-grell-rose break-words"
             [class]="getChangedColumnClass(line, 'qualifier')">
-            @if (generateEbdDeepLink(getQualifier(line, 'new'), formatVersionNew); as ebdLink) {
+            @if (generateEbdDeepLink(line.new?.ebd_key, formatVersionNew); as ebdLink) {
               <a
                 [href]="ebdLink"
                 target="_blank"

--- a/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
+++ b/src/app/features/comparison/components/comparison-table/comparison-table.component.ts
@@ -196,16 +196,11 @@ export class ComparisonTableComponent {
     return `${environment.bedingungsbaumBaseUrl}/tree/?format=${getFormatFromPruefi(this.pruefi)}&format_version=${formatVersion}&expression=${encodedExpression}`;
   }
 
-  generateEbdDeepLink(qualifier: string | null | undefined, formatVersion: string): string | null {
-    if (!qualifier || qualifier.trim().length === 0) {
+  generateEbdDeepLink(ebdKey: string | null | undefined, formatVersion: string): string | null {
+    if (!ebdKey) {
       return null;
     }
-    const regex = /^.*\b(?<ebd_key>E_\d+)\b.*$/;
-    const match = qualifier.match(regex);
-    if (!match?.groups) {
-      return null;
-    }
-    const ebdKey = match.groups['ebd_key']!;
+    // EBD detection now happens in the backend (side.ebd_key); we only build the link.
     return `${environment.ebdBaseUrl}/ebd/?formatversion=${formatVersion}&ebd=${ebdKey}`;
   }
 }

--- a/src/server/repository/ahbDiff.ts
+++ b/src/server/repository/ahbDiff.ts
@@ -18,6 +18,7 @@ export interface AhbDiffSide {
   line_name?: string | null;
   line_type?: string | null;
   bedingung?: string | null;
+  ebd_key?: string | null;
 }
 
 export interface AhbDiffLineJoined {

--- a/src/server/service/ahb.service.spec.ts
+++ b/src/server/service/ahb.service.spec.ts
@@ -30,6 +30,22 @@ describe('AhbService', () => {
       expect(result).toEqual({ fileType: FileType.JSON, content: ahb });
     });
 
+    it('enriches JSON lines with the detected EBD key', async () => {
+      const ahb = {
+        meta: {},
+        lines: [
+          { value_pool_entry: 'E_0004' },
+          { value_pool_entry: 'Prüfschritt E_0500 gemäß EBD' },
+          { value_pool_entry: 'no key here' },
+        ],
+      } as never;
+      mockRepository.get.mockResolvedValue(ahb);
+
+      const { content } = await service.getAhb('11001', 'FV2410', 'json');
+      const lines = (content as { lines: { ebd_key: string | null }[] }).lines;
+      expect(lines.map(l => l.ebd_key)).toEqual(['E_0004', 'E_0500', null]);
+    });
+
     it('maps xlsx to the XLSX file type', async () => {
       const buffer = Buffer.from('xlsx');
       mockRepository.get.mockResolvedValue(buffer);

--- a/src/server/service/ahb.service.ts
+++ b/src/server/service/ahb.service.ts
@@ -2,6 +2,7 @@ import { Ahb } from '../../app/core/api/models';
 import AHBRepository, { FileType, SearchPayload, SearchResult } from '../repository/ahb';
 import { ValidationError } from '../infrastructure/errors';
 import { assertPruefi, assertFormatVersion, parseFileType } from './validation';
+import { extractEbdKey } from './ebd';
 
 /**
  * Transport-agnostic application logic for AHB retrieval and search.
@@ -33,6 +34,15 @@ export default class AhbService {
 
     const fileType = parseFileType(format);
     const content = await this.repository.get(pruefi, formatVersion, fileType);
+
+    // Enrich JSON lines with the detected EBD key (single source of truth for EBD
+    // detection; the frontend/MCP build their own links from it). xlsx/csv are binary.
+    if (fileType === FileType.JSON) {
+      const ahb = content as Ahb;
+      for (const line of ahb.lines) {
+        line.ebd_key = extractEbdKey(line.value_pool_entry);
+      }
+    }
 
     return { fileType, content };
   }

--- a/src/server/service/ahbDiff.service.spec.ts
+++ b/src/server/service/ahbDiff.service.spec.ts
@@ -35,6 +35,27 @@ describe('AhbDiffService', () => {
       expect(mockRepository.getDiff).toHaveBeenCalledWith('11042', 'FV2504', 'FV2410');
     });
 
+    it('detects the EBD key per side from the qualifier', async () => {
+      const result = {
+        lines: [
+          { old: { qualifier: 'E_0401' }, new: { qualifier: 'foo' } },
+          { old: null, new: { qualifier: 'siehe E_0500' } },
+        ],
+        meta: {
+          pruefidentifikator: '11042',
+          format_version_new: 'FV2504',
+          format_version_old: 'FV2410',
+        },
+      } as never;
+      mockRepository.getDiff.mockResolvedValue(result);
+
+      const diff = await service.getDiff('11042', 'FV2504', 'FV2410');
+      expect(diff.lines[0].old?.ebd_key).toBe('E_0401');
+      expect(diff.lines[0].new?.ebd_key).toBeNull();
+      expect(diff.lines[1].old).toBeNull();
+      expect(diff.lines[1].new?.ebd_key).toBe('E_0500');
+    });
+
     it.each(['1234', 'abcde'])('rejects invalid pruefi %p', async invalid => {
       await expect(service.getDiff(invalid, 'FV2504', 'FV2410')).rejects.toThrow(
         'Invalid Prüfidentifikator format'

--- a/src/server/service/ahbDiff.service.ts
+++ b/src/server/service/ahbDiff.service.ts
@@ -1,5 +1,6 @@
 import AhbDiffRepository, { AhbDiffResult, AhbDiffSummary } from '../repository/ahbDiff';
 import { assertPruefi, assertFormatVersion } from './validation';
+import { extractEbdKey } from './ebd';
 
 /**
  * Transport-agnostic application logic for AHB version diffs.
@@ -21,7 +22,19 @@ export default class AhbDiffService {
     assertFormatVersion(formatVersionNew, 'format-version-new');
     assertFormatVersion(formatVersionOld, 'format-version-old');
 
-    return this.repository.getDiff(pruefi, formatVersionNew, formatVersionOld);
+    const result = await this.repository.getDiff(pruefi, formatVersionNew, formatVersionOld);
+
+    // Detect the EBD key per side (single source of truth; consumers build their links).
+    for (const line of result.lines) {
+      if (line.old) {
+        line.old.ebd_key = extractEbdKey(line.old.qualifier);
+      }
+      if (line.new) {
+        line.new.ebd_key = extractEbdKey(line.new.qualifier);
+      }
+    }
+
+    return result;
   }
 
   public async getSummary(

--- a/src/server/service/ebd.spec.ts
+++ b/src/server/service/ebd.spec.ts
@@ -9,8 +9,8 @@ describe('extractEbdKey', () => {
     expect(extractEbdKey('Prüfschritt E_0004 gemäß EBD')).toBe('E_0004');
   });
 
-  it('returns the first key when several are present', () => {
-    expect(extractEbdKey('E_0401 / E_0500')).toBe('E_0401');
+  it('returns the last key when several are present (parity with the old frontend regex)', () => {
+    expect(extractEbdKey('E_0401 / E_0500')).toBe('E_0500');
   });
 
   it.each([null, undefined, '', '   '])('returns null for %p', value => {

--- a/src/server/service/ebd.spec.ts
+++ b/src/server/service/ebd.spec.ts
@@ -1,0 +1,26 @@
+import { extractEbdKey } from './ebd';
+
+describe('extractEbdKey', () => {
+  it('returns the key when the value is exactly an EBD key', () => {
+    expect(extractEbdKey('E_0401')).toBe('E_0401');
+  });
+
+  it('extracts an embedded EBD key', () => {
+    expect(extractEbdKey('Prüfschritt E_0004 gemäß EBD')).toBe('E_0004');
+  });
+
+  it('returns the first key when several are present', () => {
+    expect(extractEbdKey('E_0401 / E_0500')).toBe('E_0401');
+  });
+
+  it.each([null, undefined, '', '   '])('returns null for %p', value => {
+    expect(extractEbdKey(value)).toBeNull();
+  });
+
+  it.each(['foo', 'MP-ID', 'E_', 'E_04a', 'XE_0401'])(
+    'returns null when there is no bounded EBD key (%p)',
+    value => {
+      expect(extractEbdKey(value)).toBeNull();
+    }
+  );
+});

--- a/src/server/service/ebd.ts
+++ b/src/server/service/ebd.ts
@@ -7,13 +7,20 @@
  * tables); it now lives in the business-logic layer so every transport (REST/frontend,
  * MCP, ...) gets the same detection.
  */
-const EBD_KEY_PATTERN = /\b(E_\d+)\b/;
+const EBD_KEY_PATTERN = /\bE_\d+\b/g;
 
-/** Extract the EBD key (e.g. `E_0401`) from a field value, or `null` if none is present. */
+/**
+ * Extract the EBD key (e.g. `E_0401`) from a field value, or `null` if none is present.
+ *
+ * If several keys are present, the **last** one wins — matching the behaviour of the old
+ * frontend regex (`/^.*\b(E_\d+)\b.*$/`, whose greedy prefix backtracked to the last match),
+ * so this refactor is behaviour-preserving. In practice a value_pool_entry / qualifier holds
+ * at most one EBD key.
+ */
 export function extractEbdKey(value: string | null | undefined): string | null {
   if (!value) {
     return null;
   }
-  const match = value.match(EBD_KEY_PATTERN);
-  return match ? match[1] : null;
+  const matches = value.match(EBD_KEY_PATTERN);
+  return matches ? matches[matches.length - 1] : null;
 }

--- a/src/server/service/ebd.ts
+++ b/src/server/service/ebd.ts
@@ -1,0 +1,19 @@
+/**
+ * EBD (Entscheidungsbaumdiagramm) detection — single source of truth.
+ *
+ * Some AHB lines reference a decision-tree diagram via an EBD key like `E_0401`
+ * (historically detected in the `value_pool_entry` / `qualifier` field). This used to be
+ * done with a regex in the Angular frontend (duplicated across the AHB and comparison
+ * tables); it now lives in the business-logic layer so every transport (REST/frontend,
+ * MCP, ...) gets the same detection.
+ */
+const EBD_KEY_PATTERN = /\b(E_\d+)\b/;
+
+/** Extract the EBD key (e.g. `E_0401`) from a field value, or `null` if none is present. */
+export function extractEbdKey(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const match = value.match(EBD_KEY_PATTERN);
+  return match ? match[1] : null;
+}


### PR DESCRIPTION
**PR 1 von 2** (Refactoring; das MCP-EBD-Feature kommt als stacked PR obendrauf).

Die EBD-Kennung (`E_0401`) in `value_pool_entry`/`qualifier` wurde bisher per **dupliziertem Regex** in zwei Angular-Komponenten erkannt. Diese Detektion wandert in den **Service-Layer** (`src/server/service/ebd.ts` → `extractEbdKey`) als Single Source of Truth und wird als neues optionales Feld **`ebd_key`** auf AHB-Zeilen und AHB-Diff-Seiten ausgeliefert (OpenAPI + regenerierter Client).

- `AhbService.getAhb` reichert JSON-Zeilen mit `ebd_key` an.
- `AhbDiffService.getDiff` setzt `ebd_key` je Seite aus dem `qualifier`.
- Frontend `ahb-table` + `comparison-table`: Regex raus, lesen `ebd_key` und bauen daraus den ebd.hochfrequenz.de-Link.

**Kein User-facing Verhalten geändert** — reines Refactoring + additives `ebd_key`-Feld.

Hinweis: Das Regenerieren des OpenAPI-Clients hat zusätzlich eine **vorbestehende Beschreibungs-Drift** in `filter-value.ts` synchronisiert (openapi.yml war der generierten Datei voraus).

325 Tests grün, `server:build` + `ng build` + `ng lint` + prettier sauber.