### PR TITLE
feat(mcp): EBD decision-tree jump-off in MCP tool descriptions

### DIFF
--- a/src/server/mcp/ebd-hint.ts
+++ b/src/server/mcp/ebd-hint.ts
@@ -1,0 +1,18 @@
+/**
+ * EBD jump-off hint for MCP tools.
+ *
+ * AHB lines carry an `ebd_key` (e.g. `E_0401`) detected in the business-logic layer
+ * (see `service/ebd.ts`). We do NOT fetch EBD data ourselves or emit fixed file URLs —
+ * not every EBD provides every file type, so we hand the LLM the stable raw base + the
+ * repo's own access contract (`llms.txt`) and let it discover what exists.
+ */
+export const EBD_REPO_RAW_BASE =
+  'https://raw.githubusercontent.com/Hochfrequenz/machine-readable_entscheidungsbaumdiagramme/main';
+
+export const EBD_JUMP_HINT =
+  `Some lines carry an "ebd_key" (e.g. E_0401) that references an EDI@Energy decision tree ` +
+  `(Entscheidungsbaumdiagramm). To reason about it, fetch the machine-readable data from ` +
+  `${EBD_REPO_RAW_BASE}/<formatVersion>/<ebd_key>.json (structured JSON — reason over this; a ` +
+  `<ebd_key>.puml graph may also exist). Not every EBD provides every file type — prefer .json ` +
+  `and consult the access contract at ${EBD_REPO_RAW_BASE}/llms.txt (and the per-version ` +
+  `index.json) if a file is missing.`;

--- a/src/server/mcp/server.spec.ts
+++ b/src/server/mcp/server.spec.ts
@@ -61,6 +61,15 @@ describe('MCP server (in-memory integration)', () => {
         expect(tool.description).toBeTruthy();
       }
     });
+
+    it('advertises the EBD jump-off in the get_ahb and get_ahb_diff descriptions', async () => {
+      const { tools } = await client.listTools();
+      const byName = Object.fromEntries(tools.map(t => [t.name, t]));
+      for (const name of ['get_ahb', 'get_ahb_diff']) {
+        expect(byName[name].description).toContain('ebd_key');
+        expect(byName[name].description).toContain('machine-readable_entscheidungsbaumdiagramme');
+      }
+    });
   });
 
   describe('tool calls delegate to the services', () => {

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { McpServices } from './services';
 import { toToolResult } from './result';
+import { EBD_JUMP_HINT } from './ebd-hint';
 import { SearchPayload } from '../repository/ahb';
 
 /**
@@ -67,7 +68,8 @@ export function registerAhbTools(server: McpServer, services: McpServices): void
       title: 'Get AHB',
       description:
         'Retrieve a single Anwendungshandbuch (AHB) as JSON for a Prüfidentifikator in a ' +
-        'given format version.',
+        'given format version. ' +
+        EBD_JUMP_HINT,
       inputSchema: {
         formatVersion: z.string().describe(FORMAT_VERSION_DESC),
         pruefi: z.string().describe(PRUEFI_DESC),
@@ -110,7 +112,8 @@ export function registerAhbTools(server: McpServer, services: McpServices): void
       title: 'Get AHB diff',
       description:
         'Line-level diff of one Prüfidentifikator between two format versions (added / ' +
-        'deleted / modified / unchanged lines with old and new values).',
+        'deleted / modified / unchanged lines with old and new values). ' +
+        EBD_JUMP_HINT,
       inputSchema: {
         pruefi: z.string().describe(PRUEFI_DESC),
         formatVersionNew: z.string().describe('Newer ' + FORMAT_VERSION_DESC),


### PR DESCRIPTION
> 🥞 **STACKED PR — Basis ist `refactor/ebd-detection-to-service` (PR #855), NICHT `main`.**
> Bitte erst #855 mergen, dann diesen PR auf `main` retargeten/rebasen. Der Diff hier zeigt nur die MCP-Ergänzung.

**PR 2 von 2** (baut auf dem EBD-Refactoring #855 auf).

`get_ahb`/`get_ahb_diff` liefern dank #855 pro Zeile `ebd_key`. Dieser PR gibt dem LLM den **Absprung**: in den Tool-Beschreibungen steht, wie es aus `ebd_key` + `formatVersion` die maschinenlesbaren EBD-Daten erreicht.

- **Kein Server-Fetch, keine fest ausgelieferten Datei-URLs** — nicht jeder EBD hat jeden Dateityp. Wir nennen die stabile Roh-Basis + verweisen auf `llms.txt`/`index.json`, der LLM entdeckt selbst, was existiert. `.json` wird bevorzugt.
- **`pruefi_to_key` wird bewusst nicht genutzt** (nicht ein-eindeutig).

`src/server/mcp/ebd-hint.ts` hält Basis-URL + Hinweistext; in `tools.ts` an die zwei Tool-Beschreibungen gehängt. Test in `server.spec.ts` (listTools → Beschreibung enthält `ebd_key` + Repo). Build/Lint/Tests grün.