### PR TITLE
feat(mcp): Bedingung/AHBicht jump-off in MCP tool descriptions

### DIFF
--- a/src/server/mcp/bedingung-hint.ts
+++ b/src/server/mcp/bedingung-hint.ts
@@ -1,0 +1,14 @@
+/**
+ * Bedingung (condition-expression) jump-off hint for MCP tools.
+ *
+ * AHB lines carry an `ahb_expression` (and diff sides a `line_ahb_status`) that may contain
+ * a condition expression with bracketed conditions, e.g. `Muss [2] ∧ [3]`. Unlike the EBD
+ * case there is no key to extract — the expression itself is already in the data — so this is
+ * purely an affordance telling the LLM how to resolve/evaluate those conditions with AHBicht.
+ */
+export const BEDINGUNG_JUMP_HINT =
+  `The "ahb_expression" field (and "line_ahb_status" on diff sides) may contain a condition ` +
+  `expression with bracketed conditions, e.g. "Muss [2] ∧ [3]". To resolve or evaluate those ` +
+  `conditions, use AHBicht: the Bedingungsbaum web UI (https://bedingungsbaum.hochfrequenz.de) ` +
+  `for humans, or the read-only AHBicht MCP server (from Hochfrequenz/ahbicht-functions, ` +
+  `mounted at /mcp) which parses modal marks and condition expressions.`;

--- a/src/server/mcp/server.spec.ts
+++ b/src/server/mcp/server.spec.ts
@@ -62,12 +62,16 @@ describe('MCP server (in-memory integration)', () => {
       }
     });
 
-    it('advertises the EBD jump-off in the get_ahb and get_ahb_diff descriptions', async () => {
+    it('advertises the EBD and Bedingung jump-offs in the get_ahb and get_ahb_diff descriptions', async () => {
       const { tools } = await client.listTools();
       const byName = Object.fromEntries(tools.map(t => [t.name, t]));
       for (const name of ['get_ahb', 'get_ahb_diff']) {
+        // EBD jump-off
         expect(byName[name].description).toContain('ebd_key');
         expect(byName[name].description).toContain('machine-readable_entscheidungsbaumdiagramme');
+        // Bedingung / AHBicht jump-off
+        expect(byName[name].description).toContain('ahb_expression');
+        expect(byName[name].description).toContain('ahbicht-functions');
       }
     });
   });

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -3,6 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { McpServices } from './services';
 import { toToolResult } from './result';
 import { EBD_JUMP_HINT } from './ebd-hint';
+import { BEDINGUNG_JUMP_HINT } from './bedingung-hint';
 import { SearchPayload } from '../repository/ahb';
 
 /**
@@ -69,7 +70,9 @@ export function registerAhbTools(server: McpServer, services: McpServices): void
       description:
         'Retrieve a single Anwendungshandbuch (AHB) as JSON for a Prüfidentifikator in a ' +
         'given format version. ' +
-        EBD_JUMP_HINT,
+        EBD_JUMP_HINT +
+        ' ' +
+        BEDINGUNG_JUMP_HINT,
       inputSchema: {
         formatVersion: z.string().describe(FORMAT_VERSION_DESC),
         pruefi: z.string().describe(PRUEFI_DESC),
@@ -113,7 +116,9 @@ export function registerAhbTools(server: McpServer, services: McpServices): void
       description:
         'Line-level diff of one Prüfidentifikator between two format versions (added / ' +
         'deleted / modified / unchanged lines with old and new values). ' +
-        EBD_JUMP_HINT,
+        EBD_JUMP_HINT +
+        ' ' +
+        BEDINGUNG_JUMP_HINT,
       inputSchema: {
         pruefi: z.string().describe(PRUEFI_DESC),
         formatVersionNew: z.string().describe('Newer ' + FORMAT_VERSION_DESC),


### PR DESCRIPTION
> 🥞 **STACKED PR** — Kette: `main` ← #855 (EBD-Refactor) ← #856 (MCP-EBD) ← **dieser PR**. Basis ist `feat/mcp-ebd-jumpoff`, **nicht** `main`. Erst #855, dann #856, dann diesen mergen (jeweils retargeten/rebasen).

Ergänzt einen **Bedingungs-Absprung** in den Beschreibungen von `get_ahb`/`get_ahb_diff`: `ahb_expression` (bzw. `line_ahb_status` in Diffs) kann Bedingungsausdrücke mit `[…]` enthalten. Der Hint nennt zur Auswertung **AHBicht** — die **Bedingungsbaum-Web-UI** (Mensch) **und den read-only AHBicht-MCP** (`Hochfrequenz/ahbicht-functions`, `/mcp`).

- **Nur MCP-Hint**, kein Server-Refactor: es gibt keinen Key zu extrahieren, die Expression ist bereits im Datenfeld. Reine Description-Affordance, analog zum EBD-Hint.
- `src/server/mcp/bedingung-hint.ts` + Anhängen an die zwei Tool-Beschreibungen; Test in `server.spec.ts` erweitert.

Build/Lint/Tests grün.