### PR TITLE
chore(mcp): address Copilot review nits from #855/#856/#857

### DIFF
--- a/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
+++ b/src/app/features/ahbs/components/ahb-table/ahb-table.component.html
@@ -61,9 +61,9 @@
             [innerHTML]="line.segment_code | highlight: highlight()"></td>
           <td class="px-6 py-4" [innerHTML]="line.data_element | highlight: highlight()"></td>
           <td class="px-6 py-4">
-            @if (generateEbdDeepLink(line.ebd_key) !== null) {
+            @if (generateEbdDeepLink(line.ebd_key); as ebdLink) {
               <a
-                [href]="generateEbdDeepLink(line.ebd_key)"
+                [href]="ebdLink"
                 target="_blank"
                 class="hover:underline font-bold text-hf-dunkel-blau flex flex-row gap-1 items-center">
                 <span [innerHTML]="line.value_pool_entry | highlight: highlight()"></span>

--- a/src/server/mcp/bedingung-hint.ts
+++ b/src/server/mcp/bedingung-hint.ts
@@ -1,7 +1,7 @@
 /**
  * Bedingung (condition-expression) jump-off hint for MCP tools.
  *
- * AHB lines carry an `ahb_expression` (and diff sides a `line_ahb_status`) that may contain
+ * AHB lines carry an `ahb_expression` (and diff sides carry a `line_ahb_status`) that may contain
  * a condition expression with bracketed conditions, e.g. `Muss [2] ∧ [3]`. Unlike the EBD
  * case there is no key to extract — the expression itself is already in the data — so this is
  * purely an affordance telling the LLM how to resolve/evaluate those conditions with AHBicht.

--- a/src/server/mcp/ebd-hint.ts
+++ b/src/server/mcp/ebd-hint.ts
@@ -2,7 +2,7 @@
  * EBD jump-off hint for MCP tools.
  *
  * AHB lines carry an `ebd_key` (e.g. `E_0401`) detected in the business-logic layer
- * (see `service/ebd.ts`). We do NOT fetch EBD data ourselves or emit fixed file URLs —
+ * (see `src/server/service/ebd.ts`). We do NOT fetch EBD data ourselves or emit fixed file URLs —
  * not every EBD provides every file type, so we hand the LLM the stable raw base + the
  * repo's own access contract (`llms.txt`) and let it discover what exists.
  */
@@ -12,7 +12,7 @@ export const EBD_REPO_RAW_BASE =
 export const EBD_JUMP_HINT =
   `Some lines carry an "ebd_key" (e.g. E_0401) that references an EDI@Energy decision tree ` +
   `(Entscheidungsbaumdiagramm). To reason about it, fetch the machine-readable data from ` +
-  `${EBD_REPO_RAW_BASE}/<formatVersion>/<ebd_key>.json (structured JSON — reason over this; a ` +
-  `<ebd_key>.puml graph may also exist). Not every EBD provides every file type — prefer .json ` +
+  `${EBD_REPO_RAW_BASE}/{formatVersion}/{ebd_key}.json (structured JSON — reason over this; a ` +
+  `{ebd_key}.puml graph may also exist). Not every EBD provides every file type — prefer .json ` +
   `and consult the access contract at ${EBD_REPO_RAW_BASE}/llms.txt (and the per-version ` +
   `index.json) if a file is missing.`;

--- a/src/server/mcp/server.spec.ts
+++ b/src/server/mcp/server.spec.ts
@@ -66,12 +66,14 @@ describe('MCP server (in-memory integration)', () => {
       const { tools } = await client.listTools();
       const byName = Object.fromEntries(tools.map(t => [t.name, t]));
       for (const name of ['get_ahb', 'get_ahb_diff']) {
+        const tool = byName[name];
+        expect(tool).toBeDefined();
         // EBD jump-off
-        expect(byName[name].description).toContain('ebd_key');
-        expect(byName[name].description).toContain('machine-readable_entscheidungsbaumdiagramme');
+        expect(tool.description).toContain('ebd_key');
+        expect(tool.description).toContain('machine-readable_entscheidungsbaumdiagramme');
         // Bedingung / AHBicht jump-off
-        expect(byName[name].description).toContain('ahb_expression');
-        expect(byName[name].description).toContain('ahbicht-functions');
+        expect(tool.description).toContain('ahb_expression');
+        expect(tool.description).toContain('ahbicht-functions');
       }
     });
   });


### PR DESCRIPTION
Sammel-Follow-up für die **nicht-blockierenden Copilot-Nits** der gemergten PRs #855/#856/#857:

- **ebd-hint:** Platzhalter `<formatVersion>`/`<ebd_key>` → `{formatVersion}`/`{ebd_key}` (Winkelklammern können in Clients, die Descriptions als Markdown/HTML rendern, verschwinden); JSDoc-Pfad auf `src/server/service/ebd.ts` korrigiert. *(#856)*
- **bedingung-hint:** Grammatik im Doc-Kommentar (Verb für die Diff-Seite). *(#857)*
- **server.spec:** Tool-Existenz explizit prüfen, bevor `.description` gelesen wird (klare Fehlermeldung statt TypeError). *(#856)*
- **ahb-table:** EBD-Link einmal via `@if (…; as ebdLink)` berechnen statt `generateEbdDeepLink` doppelt aufzurufen. *(#855)*

Rein kosmetisch/robustheit, kein Verhaltensänderung. Build/Lint/Tests grün.