### PR TITLE
feat: promote MCP feature on landing page (#864)

### DIFF
--- a/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.html
+++ b/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.html
@@ -92,6 +92,28 @@
           </div>
         </div>
       </div>
+
+      <!-- MCP / KI-Anbindung wide tile -->
+      <div class="mt-6 md:mt-8 flex justify-center">
+        <div
+          (click)="onMcpClick()"
+          (keydown.enter)="onMcpClick()"
+          (keydown.space)="onMcpClick()"
+          tabindex="0"
+          role="button"
+          class="w-full md:w-2/3 bg-hf-dunkel-rose rounded-3xl p-6 md:p-8 cursor-pointer transition-all duration-300 hover:scale-105 focus:ring-4 focus:ring-black/10 focus:outline-none">
+          <div class="flex items-center justify-center gap-4">
+            <img
+              src="assets/companystylesheet/icons/ai.svg"
+              alt="KI-Anbindung Icon"
+              class="w-10 h-10 md:w-12 md:h-12 flex-none" />
+            <p class="text-hf-weiches-schwarz text-sm md:text-base leading-relaxed">
+              <span class="font-bold">KI-Anbindung</span>
+              Verbinde unsere AHB-Tabellen mit deinem KI-Agenten (MCP)
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
   <app-footer />

--- a/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.ts
+++ b/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.ts
@@ -22,4 +22,8 @@ export class FeatureSelectionPageComponent {
   onComparisonClick() {
     this.router.navigate(['/compare']);
   }
+
+  onMcpClick() {
+    this.router.navigate(['/mcp-integration']);
+  }
 }


### PR DESCRIPTION
Closes #864

## What

Adds a horizontally wide **KI-Anbindung** tile below the three existing feature tiles on the `/features` landing page.

- Centered, `md:w-2/3` wide — covers the central tile plus half of each side tile above.
- AI sparkle icon (`icons/ai.svg`) to the left of a bold **KI-Anbindung** label, followed by _"Verbinde unsere AHB-Tabellen mit deinem KI-Agenten (MCP)"_.
- Background uses `bg-hf-dunkel-rose` — the same colour as the footer.
- Clicking (or Enter/Space) navigates to the existing `/mcp-integration` page; mirrors the hover/focus/keyboard behaviour of the other tiles.
- Bumps the `companystylesheet` submodule to the latest `main` (`0ef9d69`), which introduces `icons/ai.svg`.

## Verification

- `ng build` passes.
- Rendered the page with headless Chromium and confirmed it matches the "Expected" mockup in the issue.
- Reviewed by an independent agent against all four issue requirements (width, text/bold, icon, footer background) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)