### PR TITLE
feat: filter comparison Prüfi overview by market role

### DIFF
--- a/docs/plans/2026-07-20-pruefi-role-filter-design.md
+++ b/docs/plans/2026-07-20-pruefi-role-filter-design.md
@@ -1,0 +1,114 @@
+# Prüfi-Übersicht: Filter nach Marktrolle
+
+## Problem
+
+In der AHB-Vergleich-Landingpage (`comparison-landing-page`) werden Prüfidentifikatoren
+in der `pruefi-overview`-Komponente nach Format gruppiert (COMDIS, MSCONS, UTILMD, ...)
+und lassen sich bereits nach Status filtern (neu / entfernt / geändert / unverändert).
+Nutzer möchten die Liste zusätzlich nach Marktrolle filtern können (Lieferant,
+Netzbetreiber, Messstellenbetreiber (MSB), ...), um z. B. nur die für ihre eigene Rolle
+relevanten Prüfis zu sehen.
+
+Es gibt noch kein "Marktrolle"-Feld auf Prüfi-Ebene. Es existiert aber bereits das
+Konzept der Kommunikationsrichtung (`Kommunikationsrichtung = { sender, empfaenger }`)
+auf AHB-Zeilen-Ebene (`AhbLine.direction`), das in der Search-Feature bereits als
+Sender-/Empfänger-Filter verwendet wird (`RichtungCacheService`,
+`GET /api/direction-values`). Die Rollen-Werte darin sind Rohcodes wie `LF`, `LFA`,
+`LFN`, `NB`, `MSB`, `MSBA`, `MSBN`, `ESA`.
+
+## Entscheidung
+
+"Marktrolle" = dieselben Sender-/Empfänger-Codes, aggregiert auf Prüfi-Ebene und zu
+Basis-Rollen gruppiert (z. B. `LF`, `LFA`, `LFN` → "Lieferant"). Ein Prüfi passt zu einer
+gewählten Rolle, wenn die Rolle irgendwo als Sender **oder** Empfänger in diesem Prüfi
+vorkommt. Mehrere ausgewählte Rollen werden mit ODER verknüpft.
+
+## Backend
+
+`GET /api/pruefidentifikatoren/{format-version}` (`getPruefis`) bekommt ein neues,
+additives Feld `roles: string[]` (Rohcodes, z. B. `["LF", "NB"]`) pro Prüfi.
+
+`FormatVersionRepository.listPruefisByFormatVersion`
+(`src/server/repository/formatVersion.ts:36`) führt zusätzlich eine Query im Stil von
+`RichtungRepository.getDistinctValues` (`src/server/repository/richtung.ts:20-32`) aus,
+aber gruppiert nach `pruefidentifikator`:
+
+```sql
+SELECT DISTINCT pruefidentifikator,
+  json_extract(je.value, '$.sender') as sender,
+  json_extract(je.value, '$.empfaenger') as empfaenger
+FROM v_ahbtabellen, json_each(v_ahbtabellen.direction) as je
+WHERE format_version = :formatVersion AND direction IS NOT NULL
+```
+
+Die Ergebniszeilen werden serverseitig nach `pruefidentifikator` gruppiert; Sender- und
+Empfänger-Werte werden je Prüfi in einem `Set<string>` vereinigt und als `roles` in die
+bestehende `PruefiWithName`-Liste gemischt. Eine zusätzliche Query, kein N+1, kein neuer
+Netzwerk-Roundtrip auf Client-Seite.
+
+`openapi.yml` (Schema um `getPruefis`, aktuell Zeilen 240-249) bekommt das neue optionale
+`roles`-Array. Additive Änderung, rückwärtskompatibel. Angular-Client-Typen werden
+neu generiert (`ng-openapi-gen`).
+
+## Frontend
+
+### Rollen-Mapping (`src/app/shared/utils/role-mapping.utils.ts`, neu)
+
+Analog zu `pruefi-format.utils.ts`:
+
+```ts
+export const ROLE_GROUPS: Record<string, { label: string; codes: string[] }> = {
+  LF:  { label: 'Lieferant',              codes: ['LF', 'LFA', 'LFN'] },
+  NB:  { label: 'Netzbetreiber',          codes: ['NB'] },
+  MSB: { label: 'Messstellenbetreiber',   codes: ['MSB', 'MSBA', 'MSBN'] },
+  ESA: { label: 'Energieserviceanbieter', codes: ['ESA'] },
+};
+
+export function getBaseRoleKey(code: string): string | null;
+export function getRolesForPruefi(codes: string[]): string[]; // distinct base-role keys
+export function getAllRoleKeys(): string[];
+```
+
+Codes, die keiner Gruppe zugeordnet werden können, liefern `null` bei
+`getBaseRoleKey` und werden beim Rollen-Filtern stillschweigend ignoriert (kein
+"Andere"-Chip). Das entspricht dem bestehenden Fallback-Verhalten von
+`getFormatFromPruefi` (`'Unbekannt'`-Gruppe), nur ohne eigene Sammel-Kategorie.
+
+### `pruefi-overview.component.ts`
+
+- `PruefiComparison` bekommt `roles: string[]` (Rohcodes aus der API, unverändert
+  übernommen in `processComparison()`).
+- Neue, aus `getAllRoleKeys()` **dynamisch** aufgebaute Toggle-Signale (ein
+  `WritableSignal<boolean>`, Default `true`), analog zu den bestehenden
+  `filterToggles: FilterToggle[]` (`pruefi-overview.component.ts:83-115`) — im
+  Unterschied zu Status/Format sind Rollen datengetrieben, nicht hartkodiert.
+- `filteredPruefisCache` bekommt einen zusätzlichen Filterschritt: ein Prüfi ist
+  sichtbar, wenn `getRolesForPruefi(pruefi.roles)` mindestens eine aktuell aktivierte
+  Rolle enthält (ODER-Verknüpfung über ausgewählte Rollen).
+- Prüfis mit `roles: []` (keine Richtungsdaten) werden unabhängig vom Rollenfilter
+  immer angezeigt — gleiche "permissive default"-Philosophie wie bei fehlenden
+  Diff-Summary-Daten in `isPruefiVisible()`.
+
+### Template
+
+Rollen-Pills werden in derselben Zeile wie die bestehenden Status-Toggles
+(`pruefi-overview.component.html:19-36`) gerendert, gleiches Button-Styling, aber mit
+Rollen-Label statt `+/−/~/=`-Symbol.
+
+## Tests
+
+- `formatVersion.spec.ts`: `roles` wird korrekt aus mehrzeiligem `json_each`-Output pro
+  Prüfi aggregiert und dedupliziert (inkl. Prüfi mit unterschiedlichen
+  Richtungs-Paaren über mehrere Zeilen).
+- `role-mapping.utils.spec.ts` (neu): Code-zu-Gruppe-Mapping inkl. unbekannter Codes
+  (`null`).
+- `pruefi-overview.component.spec.ts`: Rollen-Toggle filtert sichtbare Liste, mehrere
+  aktive Rollen = ODER, Prüfi mit ausschließlich unbekannten Codes bleibt bei jeder
+  Rollen-Kombination sichtbar.
+
+## Out of scope
+
+- `ahb-diff-summary` und die Einzel-Prüfi-Vergleichsseite bleiben unverändert — der
+  Filter betrifft nur die Übersichtsliste der Landingpage.
+- Keine Persistierung der Filterauswahl (Query-Params o. ä.) — analog zum bestehenden
+  Status-Filter, der ebenfalls nicht persistiert wird.

--- a/docs/plans/2026-07-20-pruefi-role-filter-design.md
+++ b/docs/plans/2026-07-20-pruefi-role-filter-design.md
@@ -6,15 +6,15 @@ In der AHB-Vergleich-Landingpage (`comparison-landing-page`) werden Prüfidentif
 in der `pruefi-overview`-Komponente nach Format gruppiert (COMDIS, MSCONS, UTILMD, ...)
 und lassen sich bereits nach Status filtern (neu / entfernt / geändert / unverändert).
 Nutzer möchten die Liste zusätzlich nach Marktrolle filtern können (Lieferant,
-Netzbetreiber, Messstellenbetreiber (MSB), ...), um z. B. nur die für ihre eigene Rolle
-relevanten Prüfis zu sehen.
+Netzbetreiber, Messstellenbetreiber (MSB), Übertragungsnetzbetreiber (ÜNB), ...), um
+z. B. nur die für ihre eigene Rolle relevanten Prüfis zu sehen.
 
 Es gibt noch kein "Marktrolle"-Feld auf Prüfi-Ebene. Es existiert aber bereits das
 Konzept der Kommunikationsrichtung (`Kommunikationsrichtung = { sender, empfaenger }`)
 auf AHB-Zeilen-Ebene (`AhbLine.direction`), das in der Search-Feature bereits als
 Sender-/Empfänger-Filter verwendet wird (`RichtungCacheService`,
 `GET /api/direction-values`). Die Rollen-Werte darin sind Rohcodes wie `LF`, `LFA`,
-`LFN`, `NB`, `MSB`, `MSBA`, `MSBN`, `ESA`.
+`LFN`, `NB`, `MSB`, `MSBA`, `MSBN`, `ESA`, `ÜNB`.
 
 ## Entscheidung
 
@@ -62,6 +62,7 @@ export const ROLE_GROUPS: Record<string, { label: string; codes: string[] }> = {
   NB: { label: 'Netzbetreiber', codes: ['NB'] },
   MSB: { label: 'Messstellenbetreiber', codes: ['MSB', 'MSBA', 'MSBN'] },
   ESA: { label: 'Energieserviceanbieter', codes: ['ESA'] },
+  ÜNB: { label: 'Übertragungsnetzbetreiber', codes: ['ÜNB', 'ÜNB (Strom)'] },
 };
 
 export function getBaseRoleKey(code: string): string | null;

--- a/docs/plans/2026-07-20-pruefi-role-filter-design.md
+++ b/docs/plans/2026-07-20-pruefi-role-filter-design.md
@@ -58,9 +58,9 @@ Analog zu `pruefi-format.utils.ts`:
 
 ```ts
 export const ROLE_GROUPS: Record<string, { label: string; codes: string[] }> = {
-  LF:  { label: 'Lieferant',              codes: ['LF', 'LFA', 'LFN'] },
-  NB:  { label: 'Netzbetreiber',          codes: ['NB'] },
-  MSB: { label: 'Messstellenbetreiber',   codes: ['MSB', 'MSBA', 'MSBN'] },
+  LF: { label: 'Lieferant', codes: ['LF', 'LFA', 'LFN'] },
+  NB: { label: 'Netzbetreiber', codes: ['NB'] },
+  MSB: { label: 'Messstellenbetreiber', codes: ['MSB', 'MSBA', 'MSBN'] },
   ESA: { label: 'Energieserviceanbieter', codes: ['ESA'] },
 };
 
@@ -87,7 +87,7 @@ Codes, die keiner Gruppe zugeordnet werden können, liefern `null` bei
   Rolle enthält (ODER-Verknüpfung über ausgewählte Rollen).
 - Prüfis mit `roles: []` (keine Richtungsdaten) werden unabhängig vom Rollenfilter
   immer angezeigt — gleiche "permissive default"-Philosophie wie bei fehlenden
-  Diff-Summary-Daten in `isPruefiVisible()`.
+  Diff-Summary-Daten in `filteredPruefisCache`.
 
 ### Template
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -247,6 +247,14 @@ paths:
                     name:
                       type: string
                       example: 'Pruefidentifikator Name'
+                    roles:
+                      type: array
+                      description: >-
+                        Distinct sender/empfaenger role codes that appear anywhere in
+                        this Pruefidentifikator's AHB lines
+                      items:
+                        type: string
+                      example: ['LF', 'NB']
   /version:
     get:
       tags:

--- a/src/app/core/api/fn/prufidentifikatoren/get-pruefis.ts
+++ b/src/app/core/api/fn/prufidentifikatoren/get-pruefis.ts
@@ -21,6 +21,11 @@ export interface GetPruefis$Params {
 export function getPruefis(http: HttpClient, rootUrl: string, params: GetPruefis$Params, context?: HttpContext): Observable<StrictHttpResponse<Array<{
 'pruefidentifikator'?: string;
 'name'?: string;
+
+/**
+ * Distinct sender/empfaenger role codes that appear anywhere in this Pruefidentifikator's AHB lines
+ */
+'roles'?: Array<string>;
 }>>> {
   const rb = new RequestBuilder(rootUrl, getPruefis.PATH, 'get');
   if (params) {
@@ -35,6 +40,11 @@ export function getPruefis(http: HttpClient, rootUrl: string, params: GetPruefis
       return r as StrictHttpResponse<Array<{
       'pruefidentifikator'?: string;
       'name'?: string;
+      
+      /**
+       * Distinct sender/empfaenger role codes that appear anywhere in this Pruefidentifikator's AHB lines
+       */
+      'roles'?: Array<string>;
       }>>;
     })
   );

--- a/src/app/core/api/services/prufidentifikatoren.service.ts
+++ b/src/app/core/api/services/prufidentifikatoren.service.ts
@@ -40,6 +40,11 @@ export class PrufidentifikatorenService extends BaseService {
   getPruefis$Response(params: GetPruefis$Params, context?: HttpContext): Observable<StrictHttpResponse<Array<{
 'pruefidentifikator'?: string;
 'name'?: string;
+
+/**
+ * Distinct sender/empfaenger role codes that appear anywhere in this Pruefidentifikator's AHB lines
+ */
+'roles'?: Array<string>;
 }>>> {
     return getPruefis(this.http, this.rootUrl, params, context);
   }
@@ -57,14 +62,29 @@ export class PrufidentifikatorenService extends BaseService {
   getPruefis(params: GetPruefis$Params, context?: HttpContext): Observable<Array<{
 'pruefidentifikator'?: string;
 'name'?: string;
+
+/**
+ * Distinct sender/empfaenger role codes that appear anywhere in this Pruefidentifikator's AHB lines
+ */
+'roles'?: Array<string>;
 }>> {
     return this.getPruefis$Response(params, context).pipe(
       map((r: StrictHttpResponse<Array<{
 'pruefidentifikator'?: string;
 'name'?: string;
+
+/**
+ * Distinct sender/empfaenger role codes that appear anywhere in this Pruefidentifikator's AHB lines
+ */
+'roles'?: Array<string>;
 }>>): Array<{
 'pruefidentifikator'?: string;
 'name'?: string;
+
+/**
+ * Distinct sender/empfaenger role codes that appear anywhere in this Pruefidentifikator's AHB lines
+ */
+'roles'?: Array<string>;
 }> => r.body)
     );
   }

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.html
@@ -32,6 +32,21 @@
             {{ toggle.symbol }}{{ getFilterCount(toggle.key) }}
           </button>
         }
+        @if (roleToggles.length > 0) {
+          <span class="w-px self-stretch bg-hf-dunkel-rose opacity-30 mx-1"></span>
+        }
+        @for (roleToggle of roleToggles; track roleToggle.key) {
+          <button
+            type="button"
+            (click)="toggleRoleFilter(roleToggle)"
+            [class.opacity-40]="!roleToggle.signal()"
+            class="px-3 py-1.5 rounded font-medium cursor-pointer transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-1 hover:ring-2 bg-white text-hf-text-color focus:ring-gray-400 hover:ring-gray-400"
+            [attr.aria-pressed]="roleToggle.signal() ? 'true' : 'false'"
+            [attr.aria-label]="'Rolle ' + roleToggle.label + ' ein-/ausblenden'"
+            [title]="'Rolle ' + roleToggle.label + ' ein-/ausblenden'">
+            {{ roleToggle.label }}
+          </button>
+        }
       </div>
     </div>
 

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.spec.ts
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.spec.ts
@@ -283,6 +283,7 @@ describe('PruefiOverviewComponent', () => {
         existsInOld: false,
         existsInNew: true,
         status: PruefiStatus.ADDED,
+        roles: [],
       };
       expect(component.getRowClass(pruefi)).toBe('bg-hf-positive-light');
     });
@@ -294,6 +295,7 @@ describe('PruefiOverviewComponent', () => {
         existsInOld: true,
         existsInNew: false,
         status: PruefiStatus.REMOVED,
+        roles: [],
       };
       expect(component.getRowClass(pruefi)).toBe('bg-hf-negative-light');
     });
@@ -305,6 +307,7 @@ describe('PruefiOverviewComponent', () => {
         existsInOld: true,
         existsInNew: true,
         status: PruefiStatus.UNCHANGED,
+        roles: [],
       };
       expect(component.getRowClass(pruefi)).toBe('');
     });
@@ -357,83 +360,6 @@ describe('PruefiOverviewComponent', () => {
       expect(component.showIdentical()).toBe(true);
       component.toggleFilter(component.filterToggles.find(t => t.key === 'identical')!);
       expect(component.showIdentical()).toBe(false);
-    });
-  });
-
-  describe('isPruefiVisible', () => {
-    it('should return showAdded value for ADDED status', () => {
-      const pruefi = {
-        pruefidentifikator: '11001',
-        name: 'Test',
-        existsInOld: false,
-        existsInNew: true,
-        status: PruefiStatus.ADDED,
-      };
-
-      expect(component.isPruefiVisible(pruefi)).toBe(true);
-      component.showAdded.set(false);
-      expect(component.isPruefiVisible(pruefi)).toBe(false);
-    });
-
-    it('should return showRemoved value for REMOVED status', () => {
-      const pruefi = {
-        pruefidentifikator: '11001',
-        name: 'Test',
-        existsInOld: true,
-        existsInNew: false,
-        status: PruefiStatus.REMOVED,
-      };
-
-      expect(component.isPruefiVisible(pruefi)).toBe(true);
-      component.showRemoved.set(false);
-      expect(component.isPruefiVisible(pruefi)).toBe(false);
-    });
-
-    it('should return true for UNCHANGED when diff summary not loaded', () => {
-      const pruefi = {
-        pruefidentifikator: '11001',
-        name: 'Test',
-        existsInOld: true,
-        existsInNew: true,
-        status: PruefiStatus.UNCHANGED,
-      };
-
-      // No diff summary loaded - should show by default
-      expect(component.isPruefiVisible(pruefi)).toBe(true);
-    });
-
-    it('should return showChanged value for UNCHANGED with line changes', () => {
-      const pruefi = {
-        pruefidentifikator: '11001',
-        name: 'Test',
-        existsInOld: true,
-        existsInNew: true,
-        status: PruefiStatus.UNCHANGED,
-      };
-
-      // Set diff summary with changes
-      component.diffSummary.set({ '11001': { added: 1, deleted: 0, modified: 0 } });
-
-      expect(component.isPruefiVisible(pruefi)).toBe(true);
-      component.showChanged.set(false);
-      expect(component.isPruefiVisible(pruefi)).toBe(false);
-    });
-
-    it('should return showIdentical value for UNCHANGED without line changes', () => {
-      const pruefi = {
-        pruefidentifikator: '11001',
-        name: 'Test',
-        existsInOld: true,
-        existsInNew: true,
-        status: PruefiStatus.UNCHANGED,
-      };
-
-      // Set diff summary without changes
-      component.diffSummary.set({ '11001': { added: 0, deleted: 0, modified: 0 } });
-
-      expect(component.isPruefiVisible(pruefi)).toBe(true);
-      component.showIdentical.set(false);
-      expect(component.isPruefiVisible(pruefi)).toBe(false);
     });
   });
 
@@ -525,6 +451,78 @@ describe('PruefiOverviewComponent', () => {
 
       component.showRemoved.set(false);
       expect(component.getFilteredCount(utilmdGroup)).toBe(1);
+    }));
+  });
+
+  describe('role filtering', () => {
+    const mockPruefisWithRoles = [
+      { pruefidentifikator: '11001', name: 'Lieferant Pruefi', roles: ['LF'] },
+      { pruefidentifikator: '11002', name: 'MSB Pruefi', roles: ['MSBA'] },
+      { pruefidentifikator: '11003', name: 'Unmapped Pruefi', roles: ['XYZ'] },
+    ];
+
+    function loadWithRoles(): void {
+      mockPrufidentifikatorenService.getPruefis.mockImplementation(() => of(mockPruefisWithRoles));
+      fixture.componentRef.setInput('formatVersionOld', 'FV2410');
+      fixture.componentRef.setInput('formatVersionNew', 'FV2504');
+      fixture.detectChanges();
+      tick();
+    }
+
+    it('should show all pruefis when all role toggles are enabled', fakeAsync(() => {
+      loadWithRoles();
+
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      expect(component.getFilteredPruefis(utilmdGroup).length).toBe(3);
+    }));
+
+    it('should hide pruefis whose base role is disabled', fakeAsync(() => {
+      loadWithRoles();
+
+      component.toggleRoleFilter(component.roleToggles.find(t => t.key === 'LF')!);
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      const filtered = component.getFilteredPruefis(utilmdGroup);
+
+      expect(filtered.find(p => p.pruefidentifikator === '11001')).toBeUndefined();
+      // MSBA maps to base role MSB, still enabled
+      expect(filtered.find(p => p.pruefidentifikator === '11002')).toBeDefined();
+    }));
+
+    it('should match variant codes under their base role (MSBA -> MSB)', fakeAsync(() => {
+      loadWithRoles();
+
+      component.toggleRoleFilter(component.roleToggles.find(t => t.key === 'MSB')!);
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      const filtered = component.getFilteredPruefis(utilmdGroup);
+
+      expect(filtered.find(p => p.pruefidentifikator === '11002')).toBeUndefined();
+    }));
+
+    it('should always show pruefis with only unmapped role codes', fakeAsync(() => {
+      loadWithRoles();
+
+      // Disable every known role - the unmapped-only pruefi should remain visible
+      component.roleToggles.forEach(toggle => toggle.signal.set(false));
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      const filtered = component.getFilteredPruefis(utilmdGroup);
+
+      expect(filtered.find(p => p.pruefidentifikator === '11003')).toBeDefined();
+      expect(filtered.length).toBe(1);
+    }));
+
+    it('should OR multiple enabled roles together', fakeAsync(() => {
+      loadWithRoles();
+
+      component.roleToggles.forEach(toggle => toggle.signal.set(false));
+      component.toggleRoleFilter(component.roleToggles.find(t => t.key === 'LF')!);
+      component.toggleRoleFilter(component.roleToggles.find(t => t.key === 'MSB')!);
+
+      const utilmdGroup = component.formatGroups().find(g => g.format === 'UTILMD')!;
+      const filtered = component.getFilteredPruefis(utilmdGroup);
+
+      // 11003 stays visible too - it has only an unmapped role code, which is
+      // always shown regardless of role-toggle state
+      expect(filtered.map(p => p.pruefidentifikator).sort()).toEqual(['11001', '11002', '11003']);
     }));
   });
 });

--- a/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
+++ b/src/app/features/comparison/components/pruefi-overview/pruefi-overview.component.ts
@@ -18,6 +18,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AhbService, PrufidentifikatorenService } from '../../../../core/api';
 import { AhbDiffSummary } from '../../../../core/api/models';
 import { getFormatFromPruefi, getAllFormats } from '../../../../shared/utils/pruefi-format.utils';
+import {
+  getAllRoleKeys,
+  getRoleLabel,
+  getRolesForPruefi,
+} from '../../../../shared/utils/role-mapping.utils';
 
 export const PruefiStatus = {
   ADDED: 'added',
@@ -33,6 +38,7 @@ interface PruefiComparison {
   existsInOld: boolean;
   existsInNew: boolean;
   status: PruefiStatusType;
+  roles: string[];
 }
 
 interface FormatGroup {
@@ -50,6 +56,12 @@ interface FilterToggle {
   symbol: string;
   title: string;
   colorClasses: string;
+}
+
+interface RoleToggle {
+  key: string;
+  signal: WritableSignal<boolean>;
+  label: string;
 }
 
 @Component({
@@ -79,6 +91,12 @@ export class PruefiOverviewComponent implements OnChanges {
   showRemoved = signal(true);
   showChanged = signal(true);
   showIdentical = signal(true);
+
+  readonly roleToggles: RoleToggle[] = getAllRoleKeys().map(key => ({
+    key,
+    signal: signal(true),
+    label: getRoleLabel(key),
+  }));
 
   readonly filterToggles: FilterToggle[] = [
     {
@@ -154,27 +172,34 @@ export class PruefiOverviewComponent implements OnChanges {
     const showRemoved = this.showRemoved();
     const showChanged = this.showChanged();
     const showIdentical = this.showIdentical();
+    const enabledRoleKeys = new Set(
+      this.roleToggles.filter(toggle => toggle.signal()).map(toggle => toggle.key)
+    );
 
     const cache = new Map<string, PruefiComparison[]>();
 
     for (const group of groups) {
       const filtered = group.pruefis.filter(pruefi => {
-        if (pruefi.status === PruefiStatus.ADDED) {
-          return showAdded;
-        }
-        if (pruefi.status === PruefiStatus.REMOVED) {
-          return showRemoved;
-        }
-        // For unchanged status, check line changes
-        const stats = diffSummary[pruefi.pruefidentifikator];
-        if (stats) {
-          if (stats.added > 0 || stats.deleted > 0 || stats.modified > 0) {
-            return showChanged;
+        const statusVisible = (() => {
+          if (pruefi.status === PruefiStatus.ADDED) {
+            return showAdded;
           }
-          return showIdentical;
-        }
-        // If diff summary not loaded yet, show by default
-        return true;
+          if (pruefi.status === PruefiStatus.REMOVED) {
+            return showRemoved;
+          }
+          // For unchanged status, check line changes
+          const stats = diffSummary[pruefi.pruefidentifikator];
+          if (stats) {
+            if (stats.added > 0 || stats.deleted > 0 || stats.modified > 0) {
+              return showChanged;
+            }
+            return showIdentical;
+          }
+          // If diff summary not loaded yet, show by default
+          return true;
+        })();
+
+        return statusVisible && this.isRoleVisible(pruefi, enabledRoleKeys);
       });
       cache.set(group.format, filtered);
     }
@@ -242,8 +267,8 @@ export class PruefiOverviewComponent implements OnChanges {
   }
 
   private processComparison(
-    oldPruefis: Array<{ pruefidentifikator?: string; name?: string }>,
-    newPruefis: Array<{ pruefidentifikator?: string; name?: string }>
+    oldPruefis: Array<{ pruefidentifikator?: string; name?: string; roles?: string[] }>,
+    newPruefis: Array<{ pruefidentifikator?: string; name?: string; roles?: string[] }>
   ): void {
     // Filter out undefined values to ensure type safety in Set operations
     const oldSet = new Set(
@@ -264,6 +289,18 @@ export class PruefiOverviewComponent implements OnChanges {
       if (p.pruefidentifikator) {
         nameMap.set(p.pruefidentifikator, p.name || '');
       }
+    });
+
+    // Union roles from both format versions (a Pruefi may involve different roles
+    // across versions; any involvement in either version should be filterable)
+    const rolesMap = new Map<string, Set<string>>();
+    [...oldPruefis, ...newPruefis].forEach(p => {
+      if (!p.pruefidentifikator) {
+        return;
+      }
+      const roles = rolesMap.get(p.pruefidentifikator) ?? new Set<string>();
+      (p.roles ?? []).forEach(role => roles.add(role));
+      rolesMap.set(p.pruefidentifikator, roles);
     });
 
     // Get all unique pruefis
@@ -290,6 +327,7 @@ export class PruefiOverviewComponent implements OnChanges {
         existsInOld,
         existsInNew,
         status,
+        roles: Array.from(rolesMap.get(pruefi) ?? []),
       });
     });
 
@@ -380,26 +418,21 @@ export class PruefiOverviewComponent implements OnChanges {
     toggle.signal.update(v => !v);
   }
 
-  getFilterCount(key: FilterKey): number {
-    return this.stats()[key];
+  toggleRoleFilter(toggle: RoleToggle): void {
+    toggle.signal.update(v => !v);
   }
 
-  isPruefiVisible(pruefi: PruefiComparison): boolean {
-    if (pruefi.status === PruefiStatus.ADDED) {
-      return this.showAdded();
+  private isRoleVisible(pruefi: PruefiComparison, enabledRoleKeys: Set<string>): boolean {
+    const pruefiRoles = getRolesForPruefi(pruefi.roles);
+    // Pruefis with no mappable role data are always shown - we can't classify them
+    if (pruefiRoles.length === 0) {
+      return true;
     }
-    if (pruefi.status === PruefiStatus.REMOVED) {
-      return this.showRemoved();
-    }
-    // For unchanged status, check if it has line changes
-    if (this.hasLineChanges(pruefi.pruefidentifikator)) {
-      return this.showChanged();
-    }
-    if (this.hasNoLineChanges(pruefi.pruefidentifikator)) {
-      return this.showIdentical();
-    }
-    // If diff summary not loaded yet, show by default
-    return true;
+    return pruefiRoles.some(role => enabledRoleKeys.has(role));
+  }
+
+  getFilterCount(key: FilterKey): number {
+    return this.stats()[key];
   }
 
   getFilteredPruefis(group: FormatGroup): PruefiComparison[] {

--- a/src/app/shared/utils/role-mapping.utils.spec.ts
+++ b/src/app/shared/utils/role-mapping.utils.spec.ts
@@ -1,0 +1,66 @@
+import {
+  getBaseRoleKey,
+  getRolesForPruefi,
+  getAllRoleKeys,
+  getRoleLabel,
+} from './role-mapping.utils';
+
+describe('role-mapping.utils', () => {
+  describe('getBaseRoleKey', () => {
+    it('should map base codes to themselves', () => {
+      expect(getBaseRoleKey('LF')).toBe('LF');
+      expect(getBaseRoleKey('NB')).toBe('NB');
+      expect(getBaseRoleKey('MSB')).toBe('MSB');
+      expect(getBaseRoleKey('ESA')).toBe('ESA');
+    });
+
+    it('should map variant codes to their base role', () => {
+      expect(getBaseRoleKey('LFA')).toBe('LF');
+      expect(getBaseRoleKey('LFN')).toBe('LF');
+      expect(getBaseRoleKey('MSBA')).toBe('MSB');
+      expect(getBaseRoleKey('MSBN')).toBe('MSB');
+    });
+
+    it('should return null for unknown codes', () => {
+      expect(getBaseRoleKey('UNKNOWN')).toBeNull();
+      expect(getBaseRoleKey('')).toBeNull();
+    });
+  });
+
+  describe('getRolesForPruefi', () => {
+    it('should return distinct base roles for a list of codes', () => {
+      expect(getRolesForPruefi(['LF', 'NB'])).toEqual(['LF', 'NB']);
+    });
+
+    it('should dedupe variant codes into their base role', () => {
+      const roles = getRolesForPruefi(['LF', 'LFA', 'LFN']);
+      expect(roles).toEqual(['LF']);
+    });
+
+    it('should silently drop unmapped codes', () => {
+      expect(getRolesForPruefi(['LF', 'UNKNOWN'])).toEqual(['LF']);
+      expect(getRolesForPruefi(['UNKNOWN'])).toEqual([]);
+    });
+
+    it('should return an empty array for an empty input', () => {
+      expect(getRolesForPruefi([])).toEqual([]);
+    });
+  });
+
+  describe('getAllRoleKeys', () => {
+    it('should return all known base role keys', () => {
+      expect(getAllRoleKeys()).toEqual(['LF', 'NB', 'MSB', 'ESA']);
+    });
+  });
+
+  describe('getRoleLabel', () => {
+    it('should return the human-readable label for a known role', () => {
+      expect(getRoleLabel('LF')).toBe('Lieferant');
+      expect(getRoleLabel('MSB')).toBe('Messstellenbetreiber');
+    });
+
+    it('should fall back to the key itself for an unknown role', () => {
+      expect(getRoleLabel('UNKNOWN')).toBe('UNKNOWN');
+    });
+  });
+});

--- a/src/app/shared/utils/role-mapping.utils.spec.ts
+++ b/src/app/shared/utils/role-mapping.utils.spec.ts
@@ -12,6 +12,7 @@ describe('role-mapping.utils', () => {
       expect(getBaseRoleKey('NB')).toBe('NB');
       expect(getBaseRoleKey('MSB')).toBe('MSB');
       expect(getBaseRoleKey('ESA')).toBe('ESA');
+      expect(getBaseRoleKey('ÜNB')).toBe('ÜNB');
     });
 
     it('should map variant codes to their base role', () => {
@@ -19,6 +20,7 @@ describe('role-mapping.utils', () => {
       expect(getBaseRoleKey('LFN')).toBe('LF');
       expect(getBaseRoleKey('MSBA')).toBe('MSB');
       expect(getBaseRoleKey('MSBN')).toBe('MSB');
+      expect(getBaseRoleKey('ÜNB (Strom)')).toBe('ÜNB');
     });
 
     it('should return null for unknown codes', () => {
@@ -49,7 +51,7 @@ describe('role-mapping.utils', () => {
 
   describe('getAllRoleKeys', () => {
     it('should return all known base role keys', () => {
-      expect(getAllRoleKeys()).toEqual(['LF', 'NB', 'MSB', 'ESA']);
+      expect(getAllRoleKeys()).toEqual(['LF', 'NB', 'MSB', 'ESA', 'ÜNB']);
     });
   });
 

--- a/src/app/shared/utils/role-mapping.utils.ts
+++ b/src/app/shared/utils/role-mapping.utils.ts
@@ -13,6 +13,7 @@ export const ROLE_GROUPS: Record<string, RoleGroup> = {
   NB: { label: 'Netzbetreiber', codes: ['NB'] },
   MSB: { label: 'Messstellenbetreiber', codes: ['MSB', 'MSBA', 'MSBN'] },
   ESA: { label: 'Energieserviceanbieter', codes: ['ESA'] },
+  ÜNB: { label: 'Übertragungsnetzbetreiber', codes: ['ÜNB', 'ÜNB (Strom)'] },
 };
 
 /**

--- a/src/app/shared/utils/role-mapping.utils.ts
+++ b/src/app/shared/utils/role-mapping.utils.ts
@@ -1,0 +1,58 @@
+export interface RoleGroup {
+  label: string;
+  codes: string[];
+}
+
+/**
+ * Maps raw sender/empfaenger role codes (as stored in Kommunikationsrichtung) to
+ * human-readable base market roles. Variant codes (e.g. LFA/LFN for old/new supplier
+ * during a switch) are grouped under their base role.
+ */
+export const ROLE_GROUPS: Record<string, RoleGroup> = {
+  LF: { label: 'Lieferant', codes: ['LF', 'LFA', 'LFN'] },
+  NB: { label: 'Netzbetreiber', codes: ['NB'] },
+  MSB: { label: 'Messstellenbetreiber', codes: ['MSB', 'MSBA', 'MSBN'] },
+  ESA: { label: 'Energieserviceanbieter', codes: ['ESA'] },
+};
+
+/**
+ * Get the base role key (e.g. 'LF') for a raw role code (e.g. 'LFA').
+ * Returns null for codes that don't belong to any known role group.
+ */
+export function getBaseRoleKey(code: string): string | null {
+  for (const [key, group] of Object.entries(ROLE_GROUPS)) {
+    if (group.codes.includes(code)) {
+      return key;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get the distinct base role keys (e.g. ['LF', 'MSB']) present in a Pruefi's raw role codes.
+ * Unmapped codes are silently dropped.
+ */
+export function getRolesForPruefi(codes: string[]): string[] {
+  const roles = new Set<string>();
+  for (const code of codes) {
+    const key = getBaseRoleKey(code);
+    if (key) {
+      roles.add(key);
+    }
+  }
+  return Array.from(roles);
+}
+
+/**
+ * Get all known base role keys in the order they should be displayed.
+ */
+export function getAllRoleKeys(): string[] {
+  return Object.keys(ROLE_GROUPS);
+}
+
+/**
+ * Get the human-readable label for a base role key.
+ */
+export function getRoleLabel(key: string): string {
+  return ROLE_GROUPS[key]?.label ?? key;
+}

--- a/src/server/repository/formatVersion.spec.ts
+++ b/src/server/repository/formatVersion.spec.ts
@@ -83,9 +83,9 @@ describe('FormatVersionRepository', () => {
     it('should throw NotFoundError when no pruefis exist for the format version', async () => {
       mockQueryBuilder.getRawMany.mockResolvedValue([]);
 
-      await expect(
-        formatVersionRepository.listPruefisByFormatVersion('FV9999')
-      ).rejects.toThrow(NotFoundError);
+      await expect(formatVersionRepository.listPruefisByFormatVersion('FV9999')).rejects.toThrow(
+        NotFoundError
+      );
     });
 
     it('should initialize database if not already initialized', async () => {

--- a/src/server/repository/formatVersion.spec.ts
+++ b/src/server/repository/formatVersion.spec.ts
@@ -1,0 +1,103 @@
+import { AppDataSource } from '../infrastructure/database';
+import { NotFoundError } from '../infrastructure/errors';
+import FormatVersionRepository from './formatVersion';
+
+jest.mock('../infrastructure/database');
+
+describe('FormatVersionRepository', () => {
+  let formatVersionRepository: FormatVersionRepository;
+  let mockQueryBuilder: {
+    select: jest.Mock;
+    where: jest.Mock;
+    orderBy: jest.Mock;
+    getRawMany: jest.Mock;
+  };
+  let mockRepository: {
+    createQueryBuilder: jest.Mock;
+  };
+
+  beforeEach(() => {
+    formatVersionRepository = new FormatVersionRepository();
+
+    mockQueryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn(),
+    };
+
+    mockRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+    };
+
+    (AppDataSource.getRepository as jest.Mock) = jest.fn().mockReturnValue(mockRepository);
+    (AppDataSource.query as jest.Mock) = jest.fn().mockResolvedValue([]);
+    Object.defineProperty(AppDataSource, 'isInitialized', { get: () => true });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listPruefisByFormatVersion', () => {
+    it('should aggregate distinct roles per pruefi from json_each rows', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { pruefidentifikator: '11001', description: 'Anmeldung' },
+        { pruefidentifikator: '11002', description: 'Abmeldung' },
+      ]);
+      (AppDataSource.query as jest.Mock).mockResolvedValue([
+        { pruefidentifikator: '11001', sender: 'LF', empfaenger: 'NB' },
+        { pruefidentifikator: '11001', sender: 'NB', empfaenger: 'LF' },
+        { pruefidentifikator: '11002', sender: 'MSB', empfaenger: 'NB' },
+      ]);
+
+      const result = await formatVersionRepository.listPruefisByFormatVersion('FV2410');
+
+      expect(result).toEqual([
+        { pruefidentifikator: '11001', name: 'Anmeldung', roles: ['LF', 'NB'] },
+        { pruefidentifikator: '11002', name: 'Abmeldung', roles: ['MSB', 'NB'] },
+      ]);
+    });
+
+    it('should return an empty roles array for a pruefi with no direction data', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { pruefidentifikator: '11001', description: 'Anmeldung' },
+      ]);
+      (AppDataSource.query as jest.Mock).mockResolvedValue([]);
+
+      const result = await formatVersionRepository.listPruefisByFormatVersion('FV2410');
+
+      expect(result).toEqual([{ pruefidentifikator: '11001', name: 'Anmeldung', roles: [] }]);
+    });
+
+    it('should pass the format version to the roles query', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { pruefidentifikator: '11001', description: 'Anmeldung' },
+      ]);
+
+      await formatVersionRepository.listPruefisByFormatVersion('FV2410');
+
+      expect(AppDataSource.query).toHaveBeenCalledWith(expect.any(String), ['FV2410']);
+    });
+
+    it('should throw NotFoundError when no pruefis exist for the format version', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+
+      await expect(
+        formatVersionRepository.listPruefisByFormatVersion('FV9999')
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('should initialize database if not already initialized', async () => {
+      Object.defineProperty(AppDataSource, 'isInitialized', { get: () => false });
+      (AppDataSource.initialize as jest.Mock) = jest.fn().mockResolvedValue(undefined);
+      mockQueryBuilder.getRawMany.mockResolvedValue([
+        { pruefidentifikator: '11001', description: 'Anmeldung' },
+      ]);
+
+      await formatVersionRepository.listPruefisByFormatVersion('FV2410');
+
+      expect(AppDataSource.initialize).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/repository/formatVersion.ts
+++ b/src/server/repository/formatVersion.ts
@@ -9,6 +9,7 @@ interface FormatVersionsWithPruefis {
 export interface PruefiWithName {
   pruefidentifikator: string;
   name: string;
+  roles: string[];
 }
 
 // The FormatVersionRepository class is responsible for retrieving the format versions and their related pruefis.
@@ -50,10 +51,44 @@ export default class FormatVersionRepository {
       throw new NotFoundError(`Format version ${formatVersion} does not exist`);
     }
 
+    const rolesByPruefi = await this.getRolesByPruefi(formatVersion);
+
     return pruefis.map(pruefi => ({
       pruefidentifikator: pruefi.pruefidentifikator,
       name: pruefi.description || '',
+      roles: rolesByPruefi.get(pruefi.pruefidentifikator) ?? [],
     }));
+  }
+
+  // Return the set of sender/empfaenger role codes that appear anywhere in a
+  // Pruefidentifikator's AHB lines, grouped by pruefidentifikator, for a format version.
+  private async getRolesByPruefi(formatVersion: string): Promise<Map<string, string[]>> {
+    const rows: Array<{
+      pruefidentifikator: string;
+      sender: string | null;
+      empfaenger: string | null;
+    }> = await AppDataSource.query(
+      `
+      SELECT DISTINCT pruefidentifikator,
+        json_extract(je.value, '$.sender') as sender,
+        json_extract(je.value, '$.empfaenger') as empfaenger
+      FROM v_ahbtabellen, json_each(v_ahbtabellen.direction) as je
+      WHERE format_version = ? AND direction IS NOT NULL
+      `,
+      [formatVersion]
+    );
+
+    const rolesByPruefi = new Map<string, Set<string>>();
+    for (const row of rows) {
+      const roles = rolesByPruefi.get(row.pruefidentifikator) ?? new Set<string>();
+      if (row.sender) roles.add(row.sender);
+      if (row.empfaenger) roles.add(row.empfaenger);
+      rolesByPruefi.set(row.pruefidentifikator, roles);
+    }
+
+    const result = new Map<string, string[]>();
+    rolesByPruefi.forEach((roles, pruefi) => result.set(pruefi, Array.from(roles).sort()));
+    return result;
   }
 
   private async getFormatVersionsContainerClient(): Promise<void> {

--- a/src/server/service/metadata.service.spec.ts
+++ b/src/server/service/metadata.service.spec.ts
@@ -57,7 +57,7 @@ describe('MetadataService', () => {
   describe('listPruefisByFormatVersion', () => {
     it('validates the format version before delegating', async () => {
       formatVersion.listPruefisByFormatVersion.mockResolvedValue([
-        { pruefidentifikator: '11001', name: 'x' },
+        { pruefidentifikator: '11001', name: 'x', roles: [] },
       ]);
 
       await service.listPruefisByFormatVersion('FV2410');


### PR DESCRIPTION
## Summary
- Adds a market-role filter (Lieferant, Netzbetreiber, Messstellenbetreiber, Energieserviceanbieter) to the Prüfi overview on the AHB-Vergleich comparison page, alongside the existing status filters (+/-/~/=)
- Extends `GET /api/pruefidentifikatoren/{format-version}` with a new additive `roles: string[]` field per Prüfi, aggregated from the existing sender/empfänger (Kommunikationsrichtung) direction data via a `json_each` query
- Groups variant role codes (LFA/LFN, MSBA/MSBN) under their base role on the frontend; unmapped codes are silently dropped from filtering, and Prüfis with no role data stay visible regardless of filter state
- Full design writeup: `docs/plans/2026-07-20-pruefi-role-filter-design.md`

## Test plan
- [x] `npm test` — 357 tests passing, including new backend (`formatVersion.spec.ts`), utility (`role-mapping.utils.spec.ts`), and component role-filtering tests
- [x] `npm run lint` clean
- [x] `npm run server:build` and `npm run ng:build` succeed
- [x] Manually verified in browser against the real local DB: toggling role pills correctly changes visible Prüfi counts per format group (e.g. ORDERS 50/50 → 39/50 with Lieferant/MSB/ESA disabled), and re-enabling restores full counts
- [x] Code-reviewed via subagent; one flagged issue (dead `isPruefiVisible()` method left inconsistent with new role filtering) fixed by removing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)