### PR TITLE
fix: bump reusable deploy workflow to pick up pulumi install fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -249,7 +249,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Hochfrequenz/reusable-workflows/.github/workflows/deploy.yaml@3eba9d50f57a159cb8b6177f4305aefe1d43812b
+    uses: Hochfrequenz/reusable-workflows/.github/workflows/deploy.yaml@34fe37930a5982285b67a7a9dc180805baee4e0f
     with:
       pulumi_stack_name: stage
       docker_tag: ${{ needs.build-stage.outputs.docker-tag }}
@@ -267,7 +267,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Hochfrequenz/reusable-workflows/.github/workflows/deploy.yaml@3eba9d50f57a159cb8b6177f4305aefe1d43812b
+    uses: Hochfrequenz/reusable-workflows/.github/workflows/deploy.yaml@34fe37930a5982285b67a7a9dc180805baee4e0f
     with:
       pulumi_stack_name: prod
       docker_tag: ${{ needs.build-production.outputs.docker-tag }}


### PR DESCRIPTION
## Summary
- Bumps the pinned `Hochfrequenz/reusable-workflows/.github/workflows/deploy.yaml` SHA to `34fe379` (Hochfrequenz/reusable-workflows#5), which adds a `pulumi install` step before `pulumi up` and drops the Python-era `working_directory` default.
- Fixes the stage/prod deploy jobs currently failing with `It looks like the Pulumi SDK has not been installed. Have you run pulumi install?` after `infra/` moved from Python to TypeScript (see the [failed run](https://github.com/Hochfrequenz/ahb-tabellen/actions/runs/30827218031/job/91774385664)).

## Test plan
- [x] Confirmed the new pinned commit exists on `reusable-workflows` main and includes the merged fix.
- [ ] Re-run/re-tag a stage release after merging to confirm `pulumi up` succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)