### PR TITLE
feat: feature-flag AHB Prüfi-Vergleich (hide in production)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { AuthGuard } from './guards/auth.guard';
+import { pruefiComparisonEnabledGuard } from './guards/pruefi-comparison-enabled.guard';
 
 export const routes: Routes = [
   {
@@ -25,7 +26,7 @@ export const routes: Routes = [
     loadChildren: async () =>
       (await import('./features/pruefi-comparison/pruefi-comparison.routes'))
         .PRUEFI_COMPARISON_ROUTES,
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuard, pruefiComparisonEnabledGuard],
   },
   {
     path: '',

--- a/src/app/environments/environment.docker.ts
+++ b/src/app/environments/environment.docker.ts
@@ -10,4 +10,5 @@ export const environment: EnvironmentInterface = {
   auth0ClientId: 'Hku0EniRjy4B2krnx1sCwTIOzAiVta1B',
   baseUrl: 'http://localhost:4200',
   allowSearchIndexing: false,
+  enablePruefiComparison: true,
 };

--- a/src/app/environments/environment.interface.ts
+++ b/src/app/environments/environment.interface.ts
@@ -9,4 +9,5 @@ export interface EnvironmentInterface {
   baseUrl: string;
   warmupUrl?: string;
   allowSearchIndexing: boolean;
+  enablePruefiComparison: boolean;
 }

--- a/src/app/environments/environment.prod.ts
+++ b/src/app/environments/environment.prod.ts
@@ -11,4 +11,5 @@ export const environment: EnvironmentInterface = {
   baseUrl: 'https://ahb-tabellen.hochfrequenz.de',
   warmupUrl: 'https://ahbicht.azurewebsites.net/api/ResolveConditionText/FV2504/UTILMDS/333',
   allowSearchIndexing: true,
+  enablePruefiComparison: false,
 };

--- a/src/app/environments/environment.stage.ts
+++ b/src/app/environments/environment.stage.ts
@@ -11,4 +11,5 @@ export const environment: EnvironmentInterface = {
   baseUrl: 'https://ahb-tabellen.stage.hochfrequenz.de',
   warmupUrl: 'https://ahbicht-stage.azurewebsites.net/api/ResolveConditionText/FV2504/UTILMDS/333',
   allowSearchIndexing: false,
+  enablePruefiComparison: true,
 };

--- a/src/app/environments/environment.ts
+++ b/src/app/environments/environment.ts
@@ -13,4 +13,5 @@ export const environment: EnvironmentInterface = {
   baseUrl: 'http://localhost:4200',
   warmupUrl: 'https://ahbicht-stage.azurewebsites.net/api/ResolveConditionText/FV2504/UTILMDS/333',
   allowSearchIndexing: false,
+  enablePruefiComparison: true,
 };

--- a/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.html
+++ b/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.html
@@ -93,32 +93,34 @@
         </div>
 
         <!-- AHB Pruefi Comparison Card -->
-        <div
-          (click)="onPruefiComparisonClick()"
-          (keydown.enter)="onPruefiComparisonClick()"
-          (keydown.space)="onPruefiComparisonClick()"
-          tabindex="0"
-          role="button"
-          class="bg-hf-pastell-rose rounded-3xl p-6 md:p-8 cursor-pointer transition-all duration-300 hover:scale-105 focus:ring-4 focus:ring-black/10 focus:outline-none">
-          <div class="flex flex-col items-center text-center">
-            <div class="mb-4">
-              <img
-                src="assets/companystylesheet/icons/vergleich.svg"
-                alt="AHB Prüfi-Vergleich Icon"
-                class="w-12 h-12 md:w-16 md:h-16" />
-            </div>
-            <h2 class="text-xl md:text-2xl text-hf-weiches-schwarz font-semibold mb-3">
-              AHB Prüfi-Vergleich
-            </h2>
-            <p class="text-hf-weiches-schwarz text-sm md:text-base opacity-80 leading-relaxed">
-              Zwei Prüfidentifikatoren innerhalb derselben Formatversion vergleichen und
-              Unterschiede visualisieren.
-            </p>
-            <div class="mt-4 text-xs md:text-sm text-hf-weiches-schwarz opacity-60">
-              Klicken zum Öffnen →
+        @if (showPruefiComparison) {
+          <div
+            (click)="onPruefiComparisonClick()"
+            (keydown.enter)="onPruefiComparisonClick()"
+            (keydown.space)="onPruefiComparisonClick()"
+            tabindex="0"
+            role="button"
+            class="bg-hf-pastell-rose rounded-3xl p-6 md:p-8 cursor-pointer transition-all duration-300 hover:scale-105 focus:ring-4 focus:ring-black/10 focus:outline-none">
+            <div class="flex flex-col items-center text-center">
+              <div class="mb-4">
+                <img
+                  src="assets/companystylesheet/icons/vergleich.svg"
+                  alt="AHB Prüfi-Vergleich Icon"
+                  class="w-12 h-12 md:w-16 md:h-16" />
+              </div>
+              <h2 class="text-xl md:text-2xl text-hf-weiches-schwarz font-semibold mb-3">
+                AHB Prüfi-Vergleich
+              </h2>
+              <p class="text-hf-weiches-schwarz text-sm md:text-base opacity-80 leading-relaxed">
+                Zwei Prüfidentifikatoren innerhalb derselben Formatversion vergleichen und
+                Unterschiede visualisieren.
+              </p>
+              <div class="mt-4 text-xs md:text-sm text-hf-weiches-schwarz opacity-60">
+                Klicken zum Öffnen →
+              </div>
             </div>
           </div>
-        </div>
+        }
       </div>
 
       <!-- MCP / KI-Anbindung wide tile -->

--- a/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.ts
+++ b/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { FooterComponent } from '../../../../shared/components/footer/footer.component';
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'app-feature-selection-page',
@@ -11,6 +12,8 @@ import { FooterComponent } from '../../../../shared/components/footer/footer.com
 })
 export class FeatureSelectionPageComponent {
   private router = inject(Router);
+
+  readonly showPruefiComparison = environment.enablePruefiComparison;
 
   onAhbClick() {
     this.router.navigate(['/ahb']);

--- a/src/app/guards/pruefi-comparison-enabled.guard.spec.ts
+++ b/src/app/guards/pruefi-comparison-enabled.guard.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { pruefiComparisonEnabledGuard } from './pruefi-comparison-enabled.guard';
+import { environment } from '../environments/environment';
+
+describe('pruefiComparisonEnabledGuard', () => {
+  const dummyUrlTree = {} as UrlTree;
+  let mockRouter: { createUrlTree: jest.Mock };
+
+  const runGuard = () =>
+    TestBed.runInInjectionContext(() =>
+      pruefiComparisonEnabledGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot)
+    );
+
+  beforeEach(() => {
+    mockRouter = { createUrlTree: jest.fn().mockReturnValue(dummyUrlTree) };
+    TestBed.configureTestingModule({
+      providers: [{ provide: Router, useValue: mockRouter }],
+    });
+  });
+
+  it('allows activation when the feature is enabled', () => {
+    const original = environment.enablePruefiComparison;
+    environment.enablePruefiComparison = true;
+    try {
+      expect(runGuard()).toBe(true);
+      expect(mockRouter.createUrlTree).not.toHaveBeenCalled();
+    } finally {
+      environment.enablePruefiComparison = original;
+    }
+  });
+
+  it('redirects to /features when the feature is disabled', () => {
+    const original = environment.enablePruefiComparison;
+    environment.enablePruefiComparison = false;
+    try {
+      expect(runGuard()).toBe(dummyUrlTree);
+      expect(mockRouter.createUrlTree).toHaveBeenCalledWith(['/features']);
+    } finally {
+      environment.enablePruefiComparison = original;
+    }
+  });
+});

--- a/src/app/guards/pruefi-comparison-enabled.guard.ts
+++ b/src/app/guards/pruefi-comparison-enabled.guard.ts
@@ -4,8 +4,13 @@ import { environment } from '../environments/environment';
 
 /**
  * Gates the "AHB Prüfi-Vergleich" route behind the `enablePruefiComparison`
- * environment flag. When the feature is disabled (production), a direct visit to
- * `/compare-pruefis` is redirected to the feature-selection page.
+ * environment flag. When the feature is disabled (production), a visit to
+ * `/compare-pruefis` is redirected to the feature-selection page (`/features`).
+ *
+ * Note: the route also declares `AuthGuard`, which runs first. In production an
+ * unauthenticated direct visit therefore triggers the Auth0 login redirect
+ * before this guard runs; the redirect to `/features` happens once the user is
+ * authenticated.
  */
 export const pruefiComparisonEnabledGuard: CanActivateFn = (): boolean | UrlTree => {
   if (environment.enablePruefiComparison) {

--- a/src/app/guards/pruefi-comparison-enabled.guard.ts
+++ b/src/app/guards/pruefi-comparison-enabled.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { environment } from '../environments/environment';
+
+/**
+ * Gates the "AHB Prüfi-Vergleich" route behind the `enablePruefiComparison`
+ * environment flag. When the feature is disabled (production), a direct visit to
+ * `/compare-pruefis` is redirected to the feature-selection page.
+ */
+export const pruefiComparisonEnabledGuard: CanActivateFn = (): boolean | UrlTree => {
+  if (environment.enablePruefiComparison) {
+    return true;
+  }
+  return inject(Router).createUrlTree(['/features']);
+};

--- a/src/app/shared/components/feature-switcher/feature-switcher.component.ts
+++ b/src/app/shared/components/feature-switcher/feature-switcher.component.ts
@@ -8,6 +8,8 @@ import {
 
 import { Router } from '@angular/router';
 
+import { environment } from '../../../environments/environment';
+
 interface FeatureOption {
   value: string;
   label: string;
@@ -32,7 +34,9 @@ export class FeatureSwitcherComponent {
     { value: 'ahb', label: 'AHB-Tabellen', route: '/ahb' },
     { value: 'search', label: 'Globale Suche', route: '/search' },
     { value: 'comparison', label: 'AHB Versionsvergleich', route: '/compare' },
-    { value: 'pruefi-comparison', label: 'AHB Prüfi-Vergleich', route: '/compare-pruefis' },
+    ...(environment.enablePruefiComparison
+      ? [{ value: 'pruefi-comparison', label: 'AHB Prüfi-Vergleich', route: '/compare-pruefis' }]
+      : []),
   ];
 
   toggleDropdown(event?: Event): void {


### PR DESCRIPTION
## Context

The **AHB Prüfi-Vergleich** feature (PR #885) is merged but **not ready for production release**. At the same time we want to ship the routine **data-only** SQLite update (`v2026.08.06.0`, #902).

The catch: the Prüfi-Vergleich work bundled a **schema change** into the shipped `ahb.db` — it added the new view `v_ahb_pruefi_diff` **and renamed** `v_ahb_diff` → `v_ahb_formatversion_diff`, which the existing **AHB Versionsvergleich** feature now depends on. So we can't revert the feature code to ship the data — current `main` is the code that matches the shipped DB schema.

**Solution:** a build-time feature flag that hides Prüfi-Vergleich **in production only**, so `main` (code + new data) ships while the feature stays testable everywhere else.

## Changes

- **`enablePruefiComparison`** added to `EnvironmentInterface` and all `environment.*` configs — `true` in dev/stage/docker, `false` in prod (mirrors the existing `allowSearchIndexing` pattern).
- **Route guard** `pruefiComparisonEnabledGuard` on `/compare-pruefis`: redirects to `/features` when the feature is disabled.
- **Nav dropdown** entry and **feature-selection tile** are hidden when the flag is off.

Scope is **UI-only** — the backend `GET /api/pruefi-diff/...` endpoint stays live (unreachable from the UI).

## Behavior

| Environment | Prüfi-Vergleich |
|---|---|
| local / dev / stage / docker | visible & usable |
| **production** | hidden nav entry + tile; direct visit to `/compare-pruefis` redirects to `/features` |

To re-enable in prod later, flip `enablePruefiComparison` to `true` in `environment.prod.ts`.

## Verification

- New guard unit test (both flag states) ✅
- Full suite: 382 tests / 51 suites ✅
- ESLint + Prettier on changed files ✅
- `ng build --configuration production` compiles cleanly ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)