### PR TITLE
fix: balance feature-selection card grid when Prüfi-Vergleich is hidden

### DIFF
--- a/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.html
+++ b/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.html
@@ -10,7 +10,7 @@
         </p>
       </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8" [ngClass]="cardGridColumnsClass">
         <!-- AHB Tabellen Card -->
         <div
           (click)="onAhbClick()"

--- a/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.ts
+++ b/src/app/features/feature-selection/views/feature-selection-page/feature-selection-page.component.ts
@@ -1,3 +1,4 @@
+import { NgClass } from '@angular/common';
 import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { FooterComponent } from '../../../../shared/components/footer/footer.component';
@@ -6,7 +7,7 @@ import { environment } from '../../../../environments/environment';
 @Component({
   selector: 'app-feature-selection-page',
   standalone: true,
-  imports: [FooterComponent],
+  imports: [FooterComponent, NgClass],
   changeDetection: ChangeDetectionStrategy.Eager,
   templateUrl: './feature-selection-page.component.html',
 })
@@ -14,6 +15,10 @@ export class FeatureSelectionPageComponent {
   private router = inject(Router);
 
   readonly showPruefiComparison = environment.enablePruefiComparison;
+
+  // Keep the card row balanced: a full row of 4 when the Prüfi-Vergleich card
+  // is shown, or 3 when it is hidden (otherwise 3 cards leave an empty column).
+  readonly cardGridColumnsClass = this.showPruefiComparison ? 'lg:grid-cols-4' : 'lg:grid-cols-3';
 
   onAhbClick() {
     this.router.navigate(['/ahb']);


### PR DESCRIPTION
## Problem

After #905 hides the **AHB Prüfi-Vergleich** card in production, the feature-overview grid is still fixed at `lg:grid-cols-4`. With only 3 cards visible, they sit left-aligned and leave an empty fourth column, so the row looks unbalanced.

## Fix

Drive the large-screen column count from the same `enablePruefiComparison` flag that hides the card:

- card shown (dev/stage/docker) → `lg:grid-cols-4` (unchanged, full row of 4)
- card hidden (production) → `lg:grid-cols-3` (full, evenly-spaced row of 3)

Implemented via a `cardGridColumnsClass` property bound with `[ngClass]`, so the layout stays in sync with the flag and there's no empty column in either case. Smaller breakpoints (`grid-cols-1`, `md:grid-cols-2`) are unchanged.

## Verification

- ESLint + Prettier clean
- `ng build --configuration production` compiles; both `lg:grid-cols-3` and `lg:grid-cols-4` are emitted in the output CSS
- Behavior: prod (flag off) renders a balanced 3-card row; dev/stage (flag on) unchanged 4-card row

🤖 Generated with [Claude Code](https://claude.com/claude-code)