### PR TITLE
fix: remove the dead Kontakt link from the footer

### DIFF
--- a/src/app/shared/components/footer/footer.component.html
+++ b/src/app/shared/components/footer/footer.component.html
@@ -56,14 +56,6 @@
           >
           |
           <a class="ml-1 mr-2 hover:underline" routerLink="/mcp-integration">MCP</a>
-          |
-          <a
-            class="ml-1 mr-2 hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://www.hochfrequenz.de/kontakt/"
-            >Kontakt</a
-          >
         </p>
       </div>
     </div>


### PR DESCRIPTION
`https://www.hochfrequenz.de/kontakt/` returns **HTTP 404** — the page no longer exists, so
the footer's `Kontakt` link is dead. This removes it.

**Nothing replaces it:** contact details already live on the Impressum page, whose own page
title is *"Impressum | Jetzt Kontakt aufnehmen"*. The `Impressum` link stays, so the
information is still one click away.

The dangling `|` separator that preceded the link is removed too, leaving the remaining
links correctly formed — no doubled and no trailing separator.


## Verification

- `npx jest footer.component.spec.ts` → 2 suites / 2 tests passed. `footer.component.spec.ts`
  asserts nothing about link presence or count, so no spec needed updating.
- Prettier clean on the edited file.
- `npx ng lint` could not run in this environment (Angular CLI requires Node v22.22.3+ /
  v24.15.0+; v24.11.1 present) — ran `npx eslint src/app/shared/components/footer` instead,
  which passes clean. Worth a maintainer confirming CI lint is green.
- `CHANGELOG.md` left alone: `cliff.toml` shows it is generated by git-cliff.

## One thing to decide separately

`src/app/shared/components/fallback-page/fallback-page.component.html:15` tells users
*"Bei fehlenden Daten einfach das Kontaktformular im Footer nutzen"* — which points at
nothing once this lands, and in fact already pointed at a 404. Rewording user-facing copy is
a content decision, so it is deliberately **not** in this PR.

## Context

Found while adding a fifth pill (MaKo-Prozesse) to the cross-app solutions footer in all
five MaKo apps. Design doc: `Hochfrequenz/mako_prozesse` →
`docs/plans/2026-08-11-solutions-footer-design.md`. Related issues filed here: #910
(pill labels fail WCAG AA), #911 (EBD pill label singular/plural).

## Related issues filed in this repo

- **#910** — solutions-footer pill labels fail WCAG AA (white on pastel, 1.51–2.55:1)
- **#911** — the EBD pill is labelled `Entscheidungsbaumdiagramm` (singular) where the Svelte sibling
  apps use the plural
- **#914** — `fallback-page.component.html` tells users to use "das Kontaktformular im Footer", which
  no longer exists once the dead link is removed

Design doc: `Hochfrequenz/mako_prozesse` → `docs/plans/2026-08-11-solutions-footer-design.md`
(Hochfrequenz/mako_prozesse#73).
