### PR TITLE
feat: add the MaKo-Prozesse pill to the cross-app solutions footer

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -12,6 +12,7 @@ config:
     secure: AAABAPxqz5l9dn9CRjuSdmBw1dz+WQpoqfXJ1pRz5SzsxAuKHMB8mOo+Ir3nCllS0u8VjraFpDnDqGq1SA5a6RbNeOl49eJ+
   ahb-tabellen:imageName: ghcr.io/hochfrequenz/ahb-tabellen
   ahb-tabellen:imageTag: v1.4.0
+  ahb-tabellen:makoProzesseBaseUrl: https://mako-prozesse.hochfrequenz.de
   ahb-tabellen:mcpAuth0Audience: https://ahb-tabellen.hochfrequenz.de/mcp
   ahb-tabellen:mcpAuth0IssuerBaseUrl: https://auth.hochfrequenz.de/
   ahb-tabellen:ohDearHealthCheckSecret:

--- a/infra/Pulumi.stage.yaml
+++ b/infra/Pulumi.stage.yaml
@@ -12,6 +12,10 @@ config:
     secure: AAABABkZ6JHu21N1Q6+hgJVXWzz7KkywfdZ84phM1XkWy6aTrm5zvSibf6PIxCcUJsJgeqDU3aexWUGI7ZH3nFOEIGtpoyKa
   ahb-tabellen:imageName: ghcr.io/hochfrequenz/ahb-tabellen
   ahb-tabellen:imageTag: v1.4.0-rc02
+  # not a *.stage host on purpose: MaKo-Prozesse is not deployed under this host yet in any
+  # environment (see Hochfrequenz/mako_prozesse#65); every stack points at the intended
+  # production URL until the custom domain is live
+  ahb-tabellen:makoProzesseBaseUrl: https://mako-prozesse.hochfrequenz.de
   ahb-tabellen:mcpAuth0Audience: https://ahb-tabellen.stage.hochfrequenz.de/mcp
   ahb-tabellen:mcpAuth0IssuerBaseUrl: https://auth.hochfrequenz.de/
   ahb-tabellen:ohDearHealthCheckSecret:

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -33,6 +33,14 @@ if (!ebdBaseUrl) {
     throw new Error("ebdBaseUrl must be set");
 }
 
+// MaKo-Prozesse is not deployed under this host yet, in any environment
+// (see Hochfrequenz/mako_prozesse#65), so every stack - stage included - configures the
+// intended production URL until the custom domain is live.
+const makoProzesseBaseUrl = config.get("makoProzesseBaseUrl");
+if (!makoProzesseBaseUrl) {
+    throw new Error("makoProzesseBaseUrl must be set");
+}
+
 const environment = config.get("environment");
 if (!environment) {
     throw new Error("environment must be set");
@@ -98,8 +106,12 @@ const appSettings = [
     { name: "DOCKER_REGISTRY_SERVER_USERNAME", value: "hf-krechan" }, // Provide GitHub username
     { name: "DOCKER_REGISTRY_SERVER_PASSWORD", value: ghcrToken }, // Provide GitHub token or PAT
     { name: "PORT", value: String(containerPort) },
+    // The *_BASE_URL settings below are passed for parity/documentation only and are NOT
+    // read at runtime: start.sh builds with --configuration=$ENVIRONMENT, so the sibling-app
+    // URLs are baked into the bundle from src/app/environments/*. Don't hunt for a consumer.
     { name: "BEDINGUNGSBAUM_BASE_URL", value: bedingungsbaumBaseUrl },
     { name: "EBD_BASE_URL", value: ebdBaseUrl },
+    { name: "MAKO_PROZESSE_BASE_URL", value: makoProzesseBaseUrl },
     { name: "ENVIRONMENT", value: environment },
     { name: "WEBSITES_CONTAINER_START_TIME_LIMIT", value: websitesContainerStartTimeLimit },
     { name: "OH_DEAR_HEALTH_CHECK_SECRET", value: ohDearHealthCheckSecret },

--- a/src/app/environments/environment.docker.ts
+++ b/src/app/environments/environment.docker.ts
@@ -6,6 +6,10 @@ export const environment: EnvironmentInterface = {
   bedingungsbaumBaseUrl: 'https://bedingungsbaum.stage.hochfrequenz.de',
   ebdBaseUrl: 'https://ebd.stage.hochfrequenz.de',
   fristenkalenderBaseUrl: 'https://fristenkalender.stage.hochfrequenz.de',
+  // MaKo-Prozesse is not deployed under this host yet, in any environment
+  // (see Hochfrequenz/mako_prozesse#65) - every stack points at the intended
+  // production URL until the custom domain is live
+  makoProzesseBaseUrl: 'https://mako-prozesse.hochfrequenz.de',
   auth0Domain: 'auth.hochfrequenz.de',
   auth0ClientId: 'Hku0EniRjy4B2krnx1sCwTIOzAiVta1B',
   baseUrl: 'http://localhost:4200',

--- a/src/app/environments/environment.interface.ts
+++ b/src/app/environments/environment.interface.ts
@@ -4,6 +4,13 @@ export interface EnvironmentInterface {
   bedingungsbaumBaseUrl: string;
   ebdBaseUrl: string;
   fristenkalenderBaseUrl: string;
+  /**
+   * MaKo-Prozesse is not deployed under this host yet - neither in production nor on a
+   * staging domain (see https://github.com/Hochfrequenz/mako_prozesse/issues/65). Every
+   * environment therefore points at the intended production URL until the custom domain
+   * is live; re-check once it is.
+   */
+  makoProzesseBaseUrl: string;
   auth0Domain: string;
   auth0ClientId: string;
   baseUrl: string;

--- a/src/app/environments/environment.prod.ts
+++ b/src/app/environments/environment.prod.ts
@@ -6,6 +6,10 @@ export const environment: EnvironmentInterface = {
   bedingungsbaumBaseUrl: 'https://bedingungsbaum.hochfrequenz.de',
   ebdBaseUrl: 'https://ebd.hochfrequenz.de',
   fristenkalenderBaseUrl: 'https://fristenkalender.hochfrequenz.de',
+  // this is the *intended* host: MaKo-Prozesse is not deployed under it yet
+  // (see Hochfrequenz/mako_prozesse#65), so the pill will not resolve to the app
+  // until the custom domain is live
+  makoProzesseBaseUrl: 'https://mako-prozesse.hochfrequenz.de',
   auth0Domain: 'auth.hochfrequenz.de',
   auth0ClientId: 'VSkXGqlTD7Rf5Q4n9a0h00rInEyL2ZQj',
   baseUrl: 'https://ahb-tabellen.hochfrequenz.de',

--- a/src/app/environments/environment.stage.ts
+++ b/src/app/environments/environment.stage.ts
@@ -6,6 +6,10 @@ export const environment: EnvironmentInterface = {
   bedingungsbaumBaseUrl: 'https://bedingungsbaum.stage.hochfrequenz.de',
   ebdBaseUrl: 'https://ebd.stage.hochfrequenz.de',
   fristenkalenderBaseUrl: 'https://fristenkalender.stage.hochfrequenz.de',
+  // no *.stage host here because MaKo-Prozesse is not deployed under this host yet at all
+  // (see Hochfrequenz/mako_prozesse#65); the intended production URL stands in until the
+  // custom domain is live
+  makoProzesseBaseUrl: 'https://mako-prozesse.hochfrequenz.de',
   auth0Domain: 'auth.hochfrequenz.de',
   auth0ClientId: 'Hku0EniRjy4B2krnx1sCwTIOzAiVta1B',
   baseUrl: 'https://ahb-tabellen.stage.hochfrequenz.de',

--- a/src/app/environments/environment.ts
+++ b/src/app/environments/environment.ts
@@ -8,6 +8,10 @@ export const environment: EnvironmentInterface = {
   bedingungsbaumBaseUrl: 'https://bedingungsbaum.stage.hochfrequenz.de',
   ebdBaseUrl: 'https://ebd.stage.hochfrequenz.de',
   fristenkalenderBaseUrl: 'https://fristenkalender.stage.hochfrequenz.de',
+  // MaKo-Prozesse is not deployed under this host yet, in any environment
+  // (see Hochfrequenz/mako_prozesse#65) - every stack points at the intended
+  // production URL until the custom domain is live
+  makoProzesseBaseUrl: 'https://mako-prozesse.hochfrequenz.de',
   auth0Domain: 'auth.hochfrequenz.de',
   auth0ClientId: 'Hku0EniRjy4B2krnx1sCwTIOzAiVta1B',
   baseUrl: 'http://localhost:4200',

--- a/src/app/shared/components/solutions-footer/solutions-footer.component.html
+++ b/src/app/shared/components/solutions-footer/solutions-footer.component.html
@@ -5,6 +5,7 @@
       <a class="fristenkalender" [href]="fristenkalenderUrl">Fristenkalender</a>
       <a class="ahahnb" [href]="bedingungsbaumUrl">Bedingungsbaum</a>
       <a class="entscheidungsbaum" [href]="ebdUrl">Entscheidungsbaumdiagramm</a>
+      <a class="mako" [href]="makoProzesseUrl">MaKo-Prozesse</a>
     </div>
   </div>
 </footer>

--- a/src/app/shared/components/solutions-footer/solutions-footer.component.spec.ts
+++ b/src/app/shared/components/solutions-footer/solutions-footer.component.spec.ts
@@ -1,5 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { environment } from '../../../environments/environment';
+import { environment as dockerEnvironment } from '../../../environments/environment.docker';
+import { environment as productionEnvironment } from '../../../environments/environment.prod';
+import { environment as stageEnvironment } from '../../../environments/environment.stage';
+
 import { SolutionsFooterComponent } from './solutions-footer.component';
 
 describe('SolutionsFooterComponent', () => {
@@ -18,5 +23,31 @@ describe('SolutionsFooterComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders all five solution links with their expected hrefs', () => {
+    const links = fixture.nativeElement.querySelectorAll('#solutions a');
+
+    expect(
+      Array.from(links, link => [
+        (link as HTMLAnchorElement).textContent?.trim(),
+        (link as HTMLAnchorElement).getAttribute('href'),
+      ])
+    ).toEqual([
+      ['AHB-Tabellen', environment.apiUrl],
+      ['Fristenkalender', environment.fristenkalenderBaseUrl],
+      ['Bedingungsbaum', environment.bedingungsbaumBaseUrl],
+      ['Entscheidungsbaumdiagramm', environment.ebdBaseUrl],
+      ['MaKo-Prozesse', environment.makoProzesseBaseUrl],
+    ]);
+  });
+
+  // The test above resolves `environment` to environment.ts (the dev file), so the literals
+  // that actually ship are pinned here. All environments intentionally use the same URL,
+  // see the comments in the environment files.
+  it('pins the MaKo-Prozesse URL of every built environment', () => {
+    expect(productionEnvironment.makoProzesseBaseUrl).toBe('https://mako-prozesse.hochfrequenz.de');
+    expect(stageEnvironment.makoProzesseBaseUrl).toBe('https://mako-prozesse.hochfrequenz.de');
+    expect(dockerEnvironment.makoProzesseBaseUrl).toBe('https://mako-prozesse.hochfrequenz.de');
   });
 });

--- a/src/app/shared/components/solutions-footer/solutions-footer.component.ts
+++ b/src/app/shared/components/solutions-footer/solutions-footer.component.ts
@@ -15,4 +15,5 @@ export class SolutionsFooterComponent {
   public fristenkalenderUrl = environment.fristenkalenderBaseUrl;
   public bedingungsbaumUrl = environment.bedingungsbaumBaseUrl;
   public ebdUrl = environment.ebdBaseUrl;
+  public makoProzesseUrl = environment.makoProzesseBaseUrl;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -58,6 +58,11 @@
   --pastell-mint: #c6e7d2;
   --grell-mint: #85cb9c;
 
+  /* Lila/Violett, for mako_prozesse (https://github.com/Hochfrequenz/mako_prozesse/issues/65) */
+  --pastell-lila: #d5d1f0;
+  --grell-lila: #aca3e1;
+  --dunkel-lila: #8f84d7;
+
   /* Neutral Colors */
   --neutral-grau: #e7e6e5;
   --off-white: #e7e6e5;
@@ -134,6 +139,10 @@ body {
 
 #solutions a.entscheidungsbaum {
   background-color: var(--grell-blau);
+}
+
+#solutions a.mako {
+  background-color: var(--grell-lila);
 }
 
 /* Essential responsive improvements - minimal changes */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,11 @@ module.exports = {
         white: '#ffffff',
         // the hf colors are defined in hochfrequenz.css
         // see: https://github.com/Hochfrequenz/companystylesheet/blob/933394932c5c97328a891c2bd3e72dbb6cecd357/css/hochfrequenz.css
+        // SOURCE OF TRUTH: src/assets/companystylesheet/css/hochfrequenz.css (git submodule).
+        // These hexes are a hand-maintained mirror of it, and so is the :root block in
+        // src/styles.scss - the two mirrors have already drifted (e.g. dunkel-mint exists
+        // here but not there). When adding a colour, update the submodule pin first, then
+        // both mirrors.
         hf: {
           'text-color': '#40313E',
           // Greens
@@ -44,6 +49,10 @@ module.exports = {
           'pastell-mint': '#c6e7d2',
           'grell-mint': '#85cb9c',
           'dunkel-mint': '#549976',
+          // Lila/Violett (MaKo-Prozesse)
+          'pastell-lila': '#d5d1f0',
+          'grell-lila': '#aca3e1',
+          'dunkel-lila': '#8f84d7',
           // Neutral
           'neutral-grau': '#e7e6e5',
           'off-white': '#e7e6e5',


### PR DESCRIPTION
Adds a fifth pill — **MaKo-Prozesse** — to the solutions footer, so this app links to the new
MaKo processes web app alongside the other three. The same pill is being added to `AHahnB`,
`entscheidungsbaumdiagramme` and `fristenkalender-frontend` in parallel PRs.

Design: `Hochfrequenz/mako_prozesse` → `docs/plans/2026-08-11-solutions-footer-design.md`.

> ⚠️ **This PR is knowingly non-functional at merge.** `mako-prozesse.hochfrequenz.de` is not
> deployed yet — see the merge-gate comment below. The pill will render correctly but lead to a
> certificate error until the custom domain is live. Nothing in the diff needs changing for that;
> it is purely a sequencing gate.

## The pill

`<a class="mako" [href]="makoProzesseUrl">MaKo-Prozesse</a>`, appended last. The existing four
pills are untouched — not reordered, not relabelled, not refactored into a loop.

`makoProzesseUrl` follows the existing `ebdBaseUrl` pattern exactly, across the four
`environment*.ts` files, the `environment.interface.ts` declaration, both `infra/Pulumi.*.yaml`
stacks, and the config read plus `appSettings` entry in `infra/index.ts`.

**Every environment points at the same production URL,** because the app is not deployed under
that host in *any* environment — there is no staging host to differ from. All six touched files
say so in a comment citing `mako_prozesse#65`, so a future reader re-checks rather than assuming
it was settled. (An earlier revision of this PR described it as "no *staging* deployment yet",
which was wrong and would have implied production was fine.)

## Why the colour needed two changes, not one

`#solutions a.mako { background-color: var(--grell-lila); }` alone would have shipped an
**invisible white-on-white pill**, for two independent reasons:

1. **The submodule pin was stale** — `src/assets/companystylesheet` sat one commit behind the
   commit adding the lila variables. Bumped to `bdb5667`, verified as exactly one commit, one
   file, five added lines, no icons/fonts/build output.
2. **The submodule's CSS is never loaded.** `angular.json`'s `styles` array is only
   `rose-red.css`, `src/styles.scss`, `src/tailwind.css`; `index.html` links no stylesheet; the
   submodule is consumed purely as a static asset directory for SVGs and TTFs.
   `src/styles.scss:30` admits it: *"copied from …hochfrequenz.css, because I didn't manage to
   import/include it properly"*. So that `:root` block is the only runtime definition site for
   every `--grell-*` token.

So the lila family is also copied into `styles.scss`'s `:root` — **that copy is what makes the
pill purple**, the bump keeps the reference honest. All three lila vars came along because every
other `--pastell-*` in that file is likewise unused; copying complete families keeps the mirror
diffable against upstream.

`tailwind.config.js` turned out to be a **third** mirror of these hexes and also lacked lila, so
`bg-hf-grell-lila` didn't exist for the next person — now added, with a comment naming the
submodule as source of truth and recording that the two mirrors have already drifted
independently (`dunkel-mint` exists in one and not the other).

## Tests

`solutions-footer.component.spec.ts` was a bare "should create". It now asserts all five links
with labels and hrefs, plus a case pinning the URL literal in **every built environment** — prod,
stage and docker. That matters because Jest resolves `environments/environment` to the *dev*
file, so the literals that actually ship were asserted nowhere.

```
$ npx jest solutions-footer     → 1 suite, 3 tests passed
$ npx jest                      → 51 suites, 384 tests passed
$ npx eslint <touched paths>     → clean
$ npx tsc -p tsconfig.app.json --noEmit / tsconfig.spec.json --noEmit → both clean
$ npx prettier --end-of-line auto --check <13 touched files> → all clean
```

Two environment caveats, neither caused by this change: `npx ng lint` cannot start (Angular CLI
wants Node v22.22.3+/v24.15.0+, this machine has v24.11.1), so eslint was run directly — worth a
maintainer confirming CI lint is green. And Prettier needs `--end-of-line auto` locally because
`core.autocrlf=true` fights `.prettierrc`'s `endOfLine: lf` for *every* file in the checkout,
proven against untouched `src/main.ts`. CI on Linux is unaffected.

## Known, and deliberate

- `infra/index.ts` throws if `makoProzesseBaseUrl` is unset, mirroring `ebdBaseUrl`. Both in-repo
  stacks carry the key; a stack configured outside this repo would fail its next deploy until it
  is added. The `*_BASE_URL` app settings are also **not read at runtime** — `start.sh` builds
  with `--configuration=$ENVIRONMENT`, so URLs are baked in from the env files. That is now
  recorded in a comment covering all three, so nobody hunts for a consumer.
- The EBD pill's label stays `Entscheidungsbaumdiagramm` (singular, unlike the Svelte siblings) —
  #911. Pill labels stay white on pastel (1.51–2.55:1, failing WCAG AA) — #910. Both deliberately
  out of a pill-addition PR.
- The fallback page still tells users to use "das Kontaktformular im Footer", which #912 removes —
  #914.

## Related issues filed in this repo

- **#910** — solutions-footer pill labels fail WCAG AA (white on pastel, 1.51–2.55:1)
- **#911** — the EBD pill is labelled `Entscheidungsbaumdiagramm` (singular) where the Svelte sibling
  apps use the plural
- **#914** — `fallback-page.component.html` tells users to use "das Kontaktformular im Footer", which
  no longer exists once the dead link is removed

Design doc: `Hochfrequenz/mako_prozesse` → `docs/plans/2026-08-11-solutions-footer-design.md`
(Hochfrequenz/mako_prozesse#73).
